### PR TITLE
Add hidden setting for wind turbine power multiplication

### DIFF
--- a/nullius/info.json
+++ b/nullius/info.json
@@ -1,6 +1,6 @@
 {
   "name": "nullius",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "factorio_version": "1.1",
   "title": "Nullius",
   "author": "Anachrony",

--- a/nullius/prototypes/entity/turbine.lua
+++ b/nullius/prototypes/entity/turbine.lua
@@ -59,7 +59,8 @@ for i=0,7 do
   end
 end
 
-local power_value = {1500, 4000, 12000}
+local outputMultiplyer = settings.startup["nullius-wind-turbine-energy-output-multiplyer"].value
+local power_value = {1500*outputMultiplyer, 4000*outputMultiplyer, 12000*outputMultiplyer}
 for i=1,3 do
   local scale = 0.4 + (i * 0.2)
   local power = power_value[i]

--- a/nullius/scripts/wind.lua
+++ b/nullius/scripts/wind.lua
@@ -3,7 +3,8 @@
 -- no longer expected to be updated for 1.1+ compatibility, after Nullius was designed
 -- to rely on it, so the graphics are replicated here.
 
-local base_wind_power = {1500000/60, 4000000/60, 12000000/60}
+local outputMultiplyer = settings.startup["nullius-wind-turbine-energy-output-multiplyer"].value
+local base_wind_power = {1500000*outputMultiplyer/60, 4000000*outputMultiplyer/60, 12000000*outputMultiplyer/60}
 
 function init_wind()
   global.nullius_wind_orientation = 4

--- a/nullius/settings.lua
+++ b/nullius/settings.lua
@@ -1,0 +1,10 @@
+data:extend({
+    {
+        type = "int-setting",
+        name = "nullius-wind-turbine-energy-output-multiplyer",
+        setting_type = "startup",
+        default_value = 1,
+        allowed_values = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+        hidden = true
+    }
+})


### PR DESCRIPTION
As discussed in [Taking Pull Requests on GitHub?](https://mods.factorio.com/mod/nullius/discussion/62143638c9bd9cc0f50f259a)

The change has been tested and shouldn't change Nullius behaviour at all.
Also, it shouldn't impact Nullius at runtime at all, just during initialization.