### PR TITLE
Add a checkpoint for the Lambent Nil mod

### DIFF
--- a/nullius/prototypes/checkpoint.lua
+++ b/nullius/prototypes/checkpoint.lua
@@ -2838,3 +2838,38 @@ data:extend({
     ignore_tech_cost_multiplier = true
   }
 })
+
+if mods["lambent-nil"] then
+  data:extend({
+    {
+      type = "technology",
+      name = "nullius-checkpoint-chelating-agent",
+      localised_name = {"technology-name.nullius-checkpoint", {"technology-name.nullius-analysis",
+	      {"item-name.nullius-chelating-agent"}}},
+      localised_description = {"technology-description.nullius-produce",
+	      {"technology-description.nullius-item", 1000, "nullius-chelating-agent", {"item-name.nullius-chelating-agent"}}},
+      order = "nullius-ye",
+      icons = {
+        {
+          icon = "__lambent-nil__/graphics/icons/chelating-agent.png",
+          icon_size = 64,
+          icon_mipmaps = 4
+        },
+        {
+          icon = ICONPATH .. "checkpoint.png",
+          icon_size = 64,
+          icon_mipmaps = 4,
+          scale = 1,
+          tint = {0.6, 0.6, 0.6, 0.6}
+        }
+      },
+      unit = {
+        count = 1,
+        ingredients = {{"nullius-checkpoint", 1}, {"nullius-climatology-pack", 1}},
+        time = 1
+      },
+      prerequisites = {"nullius-sodium-processing"},
+      ignore_tech_cost_multiplier = true
+    }
+  })
+end

--- a/nullius/scripts/checkpoint.lua
+++ b/nullius/scripts/checkpoint.lua
@@ -143,6 +143,10 @@ local checkpoint_data = {
   ["oxygen"] = {{ CHK_SPECIAL, STT_NET, 1, {} }}
 }
 
+if script.active_mods["lambent-nil"] then
+  checkpoint_data["chelating-agent"] = {{ CHK_ITEM, STT_PRODUCE, 1000, {{"nullius-chelating-agent"}} }}
+end
+
 
 local broken_data = {
   ["air-filter"] = 3,


### PR DESCRIPTION
Add a checkpoint for one of lambent-nil's intermediates when that mod is active.  The checkpoint is inserted at an existing tech prerequisite.

There aren't any other conditionally created checkpoints, so this change doesn't follow an existing pattern.  You may want a different code organization from what I did in the pull request.