### PR TITLE
Remove typo in item.cfg

### DIFF
--- a/nullius/locale/en/item.cfg
+++ b/nullius/locale/en/item.cfg
@@ -523,7 +523,7 @@ nullius-antimatter=An extremely dense, powerful vehicle fuel collected by an ant
 nullius-antimatter-trap=Used in a reactor to collect antimatter fuel ([item=nullius-antimatter]).
 nullius-fusion-cell=A basic nuclear fuel to power nuclear reactors ([item=nullius-reactor]).  Effective, but consumes a substantial amount of the rare tritium isotope ([fluid=nullius-tritium]).
 nullius-spent-fusion-cell=The result of consuming a fusion cell ([item=nullius-fusion-cell]) in a nuclear reactor ([item=nullius-reactor]).  Contains fused helium ([fluid=nullius-helium]).
-nullius-breeder-cell=A more advanced fusion cell, less energetic than the the basic one ([item=nullius-fusion-cell]), but which converts surplus deuterium ([fluid=nullius-deuterium]) into more valuable tritium ([fluid=nullius-tritium]).
+nullius-breeder-cell=A more advanced fusion cell, less energetic than the basic one ([item=nullius-fusion-cell]), but which converts surplus deuterium ([fluid=nullius-deuterium]) into more valuable tritium ([fluid=nullius-tritium]).
 nullius-spent-breeder-cell=The result of consuming a breeder cell ([item=nullius-breeder-cell]), which contains tritium ([fluid=nullius-tritium]).
 nullius-fission-cell=A technically simpler to harness nuclear fuel than fusion, but relies on the exotic element uranium ([item=nullius-uranium]), which is not normally found on the surface of this planet.
 nullius-spent-fission-cell=The result of consuming a fission cell ([item=nullius-fission-cell]), which can be reprocessed to extract some unreacted uranium ([item=nullius-yellowcake]).


### PR DESCRIPTION
- removes duplicated 'the'