### PR TITLE
Add proper support for Cybersyn to Train Upgrader

### DIFF
--- a/train-upgrader/scripts/station.lua
+++ b/train-upgrader/scripts/station.lua
@@ -9,7 +9,7 @@ function special_stop(stop)
   return true
 end
 
-function insert_train_schedule(train, station)
+function insert_train_schedule(train, station, cs_train)
   if ((not train.valid) or train.manual_mode) then return false end
   local sched = train.schedule
   if (sched == nil) then return false end
@@ -23,6 +23,16 @@ function insert_train_schedule(train, station)
   local ind = hi + 1
   sched.records[ind] = { station = stop_name,
       wait_conditions = {{type="time", compare_type="and", ticks=36007}} }
+  if cs_train then
+    remote.call("cybersyn", "remove_train", train.id)
+    if not cs_train.use_any_depot then
+      table.insert(
+        sched.records, 1,
+        remote.call("cybersyn", "create_direct_to_station_order", train.station)
+      )
+      ind = 3
+    end
+  end
   station.pending[train.id] = {
     train = train,
     tick = game.tick,

--- a/train-upgrader/scripts/tick.lua
+++ b/train-upgrader/scripts/tick.lua
@@ -44,6 +44,11 @@ end
 function summon_train(station)
   local train = station.train_set[station.train_index]
   if ((not train.valid) or train.manual_mode) then return end
+  local cs_train = nil
+  if remote.interfaces["cybersyn"] then
+    cs_train = remote.call("cybersyn", "read_global", "trains", train.id)
+    if cs_train and cs_train.status ~= 0 then return end
+  end
   if (not upgrade_any_carriage(train, station, false)) then return end
 
   if (station.last_summon > 0) then
@@ -56,7 +61,7 @@ function summon_train(station)
 	if ((tsl ~= nil) and (station.pending_count >= tsl)) then return end
 	station.hold = false
   end
-  insert_train_schedule(train, station)
+  insert_train_schedule(train, station, cs_train)
 end
 
 function update_train_set(station)


### PR DESCRIPTION
 - only upgrade trains that are waiting at the depot
 - remove trains so they can't be used until they return to the depot
 - add an extra record if train is "Require same depot"
 - this fixes https://github.com/GregorSamsanite/nullius/issues/25