### PR TITLE
Add support for Better Victory Screen

### DIFF
--- a/nullius/locale/en/better-victory-screen.cfg
+++ b/nullius/locale/en/better-victory-screen.cfg
@@ -1,0 +1,10 @@
+[bvs-categories]
+terraforming=Terraforming
+
+[bvs-stats]
+arthropods=Roaming Arthropods
+worms=Burrowed Worms
+fish=Swimming Fish
+trees=Healthy Trees
+grass=Grass Grown
+petroleum=Available Petroleum Locations

--- a/nullius/locale/en/misc.cfg
+++ b/nullius/locale/en/misc.cfg
@@ -153,3 +153,6 @@ faction-joined=__1__ has been recruited to __2__ from __3__.
 faction-summoned=New arrival __1__ has responded to transmissions by __2__.
 faction-quit=__1__ has left __2__ to join __3__.
 faction-absorbed=__1__ has been absorbed into __2__.
+
+[gui-game-finished]
+victory=Nauvis has been successfully terraformed!

--- a/nullius/scripts/interface.lua
+++ b/nullius/scripts/interface.lua
@@ -7,7 +7,39 @@ remote.add_interface("nullius", {
   end,
   on_character_swapped = function(data)
     change_character_entity(data.old_unit_number, data.new_character)
-  end
+  end,
+  ["better-victory-screen-statistics"] = function(winning_force)
+    local stats = { by_force = { }}
+    local surface = game.surfaces["nauvis"]
+
+    local arthropods = surface.count_entities_filtered{name = {
+        "small-biter", "medium-biter", "big-biter", "behemoth-biter",
+        "small-spitter", "medium-spitter", "big-spitter", "behemoth-spitter",
+    }}
+    local worms = surface.count_entities_filtered{name = {
+      "small-worm-turret", "medium-worm-turret", "big-worm-turret", "behemoth-worm-turret",
+    }}
+    local fish = surface.count_entities_filtered{type = "fish"}
+    local trees = surface.count_entities_filtered{type = "tree"}
+
+    local grass = surface.count_tiles_filtered{name = {
+      "grass-1", "grass-2", "grass-3", "grass-4"
+    }} / (1000 * 1000) -- Convert tiles to km2
+
+    local petroleum = surface.count_entities_filtered{name = "crude-oil"}
+
+    for force_name, force in pairs(game.forces) do
+      stats.by_force[force_name] = {["terraforming"] = { order = "a", stats = {
+        arthropods    = { value = arthropods,                 order = "a"},
+        worms         = { value = worms,                      order = "b"},
+        fish          = { value = fish,                       order = "c"},
+        trees         = { value = trees,                      order = "d"},
+        grass         = { value = grass,  unit = "area",      order = "e"},
+        petroleum     = { value = petroleum,                  order = "f"},
+      }}}
+    end
+    return stats
+  end,
 })
 
 

--- a/nullius/scripts/mission.lua
+++ b/nullius/scripts/mission.lua
@@ -179,8 +179,14 @@ function set_mission_goal(goal, amount, force)
   end
   update_mission_global()
   if (global.nullius_mission_complete) then
-    game.set_game_state{game_finished=true, player_won=true,
+
+    if remote.interfaces["better-victory-screen"] and remote.interfaces["better-victory-screen"]["trigger_victory"] then
+      remote.call("better-victory-screen", "trigger_victory", force)
+    else
+      game.set_game_state{game_finished=true, player_won=true,
 	    can_continue=true, victorious_force=force}
+    end
+
   end
 end
 

--- a/nullius/scripts/startup.lua
+++ b/nullius/scripts/startup.lua
@@ -107,8 +107,10 @@ local function reset_config()
     remote.call("freeplay", "set_created_items", {})	
     remote.call("freeplay", "set_respawn_items", {})
   end
-  if (remote.interfaces["silo_script"] ~= nil) then
-    remote.call("silo_script", "set_no_victory", true)
+  for interface, functions in pairs(remote.interfaces) do
+    if (functions["set_no_victory"] ~= nil) then
+      remote.call(interface, "set_no_victory", true)
+    end
   end
 
   init_checkpoint_prereqs()


### PR DESCRIPTION
Hello!

I've added some support for my mod [Better Victory Screen](https://mods.factorio.com/mod/better-victory-screen) and I think Nullius has some intersting information it can show during the victory screen. For example something like this (ran on a save by Glamatron):

![image](https://github.com/GregorSamsanite/nullius/assets/39875036/9b885fc3-b32c-4b69-bff8-b060e59aa611)

_(Some values are zero because they are only tracked while my mod is active)_

I've not really played Nullius, so I'm not quite sure about what information might be interesting, but I took my best guess. You have full control from your mod's side on what is shown, and what is not shown. And can change it at any time.

If you don't want to add this compatability please feel to close it :)
Would also be cool if this could maybe be an optional dependency in one of your mod packs.