### PR TITLE
Add support for Logistic Signals mod

### DIFF
--- a/nullius/prototypes/mods.lua
+++ b/nullius/prototypes/mods.lua
@@ -4120,3 +4120,36 @@ if mods["fcpu"] then
     }
   });
 end
+
+if mods["logistic-signals"] then
+  data:extend({
+    {
+      type = "recipe",
+      name = "nullius-unfulfilled-requests-combinator",
+      enabled = false,
+      always_show_made_in = true,
+      category = "small-crafting",
+      energy_required = 2,
+      ingredients = {
+        {"constant-combinator", 1},
+        {"nullius-sensor-1", 1},
+        {"programmable-speaker", 1},
+      },
+      result = "sil-unfulfilled-requests-combinator"
+    },
+    {
+      type = "recipe",
+      name = "nullius-player-requests-combinator",
+      enabled = false,
+      always_show_made_in = true,
+      category = "small-crafting",
+      energy_required = 2,
+      ingredients = {
+        {"constant-combinator", 1},
+        {"nullius-sensor-1", 1},
+        {"programmable-speaker", 1},
+      },
+      result = "sil-player-requests-combinator"
+    }
+  })
+end

--- a/nullius/prototypes/override_mod.lua
+++ b/nullius/prototypes/override_mod.lua
@@ -2453,4 +2453,14 @@ if mods["Mini_Trains"] then
 end
 
 
+if mods["logistic-signals"] then
+  data.raw.item["sil-player-requests-combinator"].order = "nullius-ls-prc"
+  data.raw.item["sil-unfulfilled-requests-combinator"].order = "nullius-ls-urc"
+  data.raw["constant-combinator"]["sil-player-requests-combinator"].minable.mining_time = 0.8
+  data.raw["constant-combinator"]["sil-unfulfilled-requests-combinator"].minable.mining_time = 0.8
+  table.insert(data.raw["technology"]["nullius-distribution-1"].effects,
+    {type = "unlock-recipe", recipe = "nullius-player-requests-combinator"})
+  table.insert(data.raw["technology"]["nullius-distribution-1"].effects,
+    {type = "unlock-recipe", recipe = "nullius-unfulfilled-requests-combinator"})
+end
 

--- a/nullius/prototypes/override_mod.lua
+++ b/nullius/prototypes/override_mod.lua
@@ -2458,7 +2458,7 @@ if mods["logistic-signals"] then
   data.raw.item["sil-unfulfilled-requests-combinator"].order = "nullius-ls-urc"
   data.raw["constant-combinator"]["sil-player-requests-combinator"].minable.mining_time = 0.8
   data.raw["constant-combinator"]["sil-unfulfilled-requests-combinator"].minable.mining_time = 0.8
-  table.insert(data.raw["technology"]["nullius-distribution-1"].effects,
+  table.insert(data.raw["technology"]["nullius-logistic-robot-1"].effects,
     {type = "unlock-recipe", recipe = "nullius-player-requests-combinator"})
   table.insert(data.raw["technology"]["nullius-distribution-1"].effects,
     {type = "unlock-recipe", recipe = "nullius-unfulfilled-requests-combinator"})


### PR DESCRIPTION
Add support for Logistic Signals mod: https://mods.factorio.com/mod/logistic-signals

Player Requests Detector is gated behind the Robotic Logistics 1 research (to get it together with character logistic requests ability).

Unfulfilled Requests Detector unlocked by Distribution 1 research, when demand chests first become available.

Both recipes take one of each Sensor 1, Memory circuit and Antenna. Feel free to suggest a better recipe, I did not think too hard about it. :)