### PR TITLE
Widening tolerance for pumps if Mini Trains exist.

### DIFF
--- a/nullius/prototypes/mods.lua
+++ b/nullius/prototypes/mods.lua
@@ -4072,11 +4072,9 @@ if mods["Mini_Trains"] then
       prerequisites = {"nullius-personal-transportation-1", "nullius-checkpoint-freight-transportation"}
     }
   })
-  -- Mini Trains fluid wagons are oddly aligned, so it helps to have a wider tolerance on pumps.
+
   data.raw["pump"]["nullius-pump-1"].fluid_wagon_connector_alignment_tolerance = 20.0 / 32.0;
   data.raw["pump"]["nullius-pump-2"].fluid_wagon_connector_alignment_tolerance = 20.0 / 32.0;
-  data.raw["pump"]["nullius-small-pump-1"].fluid_wagon_connector_alignment_tolerance = 20.0 / 32.0;
-  data.raw["pump"]["nullius-small-pump-2"].fluid_wagon_connector_alignment_tolerance = 20.0 / 32.0;
 end
 
 if mods["fcpu"] then

--- a/nullius/prototypes/mods.lua
+++ b/nullius/prototypes/mods.lua
@@ -4072,6 +4072,11 @@ if mods["Mini_Trains"] then
       prerequisites = {"nullius-personal-transportation-1", "nullius-checkpoint-freight-transportation"}
     }
   })
+  -- Mini Trains fluid wagons are oddly aligned, so it helps to have a wider tolerance on pumps.
+  data.raw["pump"]["nullius-pump-1"].fluid_wagon_connector_alignment_tolerance = 20.0 / 32.0;
+  data.raw["pump"]["nullius-pump-2"].fluid_wagon_connector_alignment_tolerance = 20.0 / 32.0;
+  data.raw["pump"]["nullius-small-pump-1"].fluid_wagon_connector_alignment_tolerance = 20.0 / 32.0;
+  data.raw["pump"]["nullius-small-pump-2"].fluid_wagon_connector_alignment_tolerance = 20.0 / 32.0;
 end
 
 if mods["fcpu"] then


### PR DESCRIPTION
Mini Trains fluid wagons are less precisely aligned with expected pump locations, so some tolerance is needed for pumps to reach properly. Mini Trains already adjusts the vanilla pump (Pump 3 in Nullius) to have a tolerance of 0.625.