### PR TITLE
Cargo drone moorings use airspace like wind turbines

### DIFF
--- a/nullius/locale/en/entity.cfg
+++ b/nullius/locale/en/entity.cfg
@@ -512,6 +512,7 @@ nullius-loader=Moves items to or from a container or machine at the rate of a ma
 nullius-align-conscription-turret=Defensive installation that fires conscription rays at rival factions automatically.
 nullius-align-concordance-transmitter=Newly arriving androids will start in a faction with an active transmitter instead of starting their own.  Protects all players and buildings from conscription while active.  Gradually reveals distant sectors.
 inserterToggleInfo=Use Shift+L to toggle between long and normal inserter (available when the extension research is unlocked)
+nullius-cargo-drone-mooring=A mooring tower.  Requires airspace unobstructed by wind turbines and other moorings.
 
 [equipment-name]
 nullius-solar-panel-1=Solar panel 1

--- a/nullius/prototypes/override_mod.lua
+++ b/nullius/prototypes/override_mod.lua
@@ -2580,13 +2580,31 @@ data.raw.car["cargo-drone"].friction = 0.003
 data.raw.item["cargo-drone-mooring-constant-combinator-refueler"].order = "nullius-b"
 data.raw.item["cargo-drone-mooring-constant-combinator-refueler"].stack_size = 10
 data.raw.item["cargo-drone-mooring-constant-combinator-refueler"].subgroup = "cargo-drone"
+data.raw.item["cargo-drone-mooring-constant-combinator-refueler"].localised_description = {"entity-description.nullius-cargo-drone-mooring"}
 data.raw.item["cargo-drone-mooring-constant-combinator-provider"].order = "nullius-c"
 data.raw.item["cargo-drone-mooring-constant-combinator-provider"].stack_size = 10
 data.raw.item["cargo-drone-mooring-constant-combinator-provider"].subgroup = "cargo-drone"
+data.raw.item["cargo-drone-mooring-constant-combinator-provider"].localised_description = {"entity-description.nullius-cargo-drone-mooring"}
 data.raw.item["cargo-drone-mooring-constant-combinator-requester"].order = "nullius-d"
 data.raw.item["cargo-drone-mooring-constant-combinator-requester"].stack_size = 10
 data.raw.item["cargo-drone-mooring-constant-combinator-requester"].subgroup = "cargo-drone"
+data.raw.item["cargo-drone-mooring-constant-combinator-requester"].localised_description = {"entity-description.nullius-cargo-drone-mooring"}
 data.raw.item["cargo-drone-depot-constant-combinator"].order = "nullius-e"
 data.raw.item["cargo-drone-depot-constant-combinator"].stack_size = 10
 data.raw.item["cargo-drone-depot-constant-combinator"].subgroup = "cargo-drone"
+data.raw.item["cargo-drone-depot-constant-combinator"].localised_description = {"entity-description.nullius-cargo-drone-mooring"}
+
+-- Collide with wind turbines
+for _, item in pairs({
+    "cargo-drone-mooring-constant-combinator-refueler",
+    "cargo-drone-mooring-constant-combinator-provider",
+    "cargo-drone-mooring-constant-combinator-requester",
+    "cargo-drone-depot-constant-combinator"
+}) do
+  local prototype = data.raw["constant-combinator"][item]
+  local cm = prototype.collision_mask or util.table.deepcopy(data.raw["utility-constants"]["default"].default_collision_masks["constant-combinator"])
+  cm.layers["layer_43"] = true
+  prototype.collision_mask = cm
+end
+
 end

--- a/nullius/scripts/build.lua
+++ b/nullius/scripts/build.lua
@@ -8,7 +8,10 @@ function entity_added(entity, handbuilt)
       local result = check_pipette(handbuilt)
       if (result ~= nil) then entity = result end
       --check_mirror(entity)
-	  end
+    elseif (entity.type == "constant-combinator" and
+            string.sub(entity.name, 1, 12) == "cargo-drone-") then
+      build_wind_mod_entity(entity)
+    end
     return
   end
 
@@ -45,7 +48,14 @@ function entity_added(entity, handbuilt)
 end
 
 function entity_removed(entity, died)
-  if (string.sub(entity.name, 1, 8) ~= "nullius-") then return end
+  if (string.sub(entity.name, 1, 8) ~= "nullius-") then
+    if (entity.type == "constant-combinator" and
+        string.sub(entity.name, 1, 12) == "cargo-drone-") then
+      remove_wind_mod_entity(entity)
+    else
+      return
+    end
+  end
   local suffix = string.sub(entity.name, 9, -2)
   if (suffix == "wind-base-") then
     remove_wind_turbine(entity, died, (string.byte(entity.name, 19) - 48))
@@ -84,6 +94,7 @@ function entity_destroyed(event)
   local unit_number = event.useful_id
   if (destroyed_stirling_engine(unit_number)) then return end
   if (destroyed_wind_turbine(unit_number)) then return end
+  if (destroyed_wind_mod_entity(unit_number)) then return end
   if (remove_beacon(unit_number)) then return end
   if (remove_turbine(unit_number)) then return end
   if (remove_transmitter(unit_number)) then return end

--- a/nullius/scripts/migrate.lua
+++ b/nullius/scripts/migrate.lua
@@ -146,6 +146,10 @@ function migrate_version(event)
   local version = parse_version(version_info.old_version)
   if (version == nil) then return end
 
+  if storage.nullius_wind_mod_entities == nil then
+    storage.nullius_wind_mod_entities = {}
+  end
+
   if(version >= 20003) then return end
   if storage.fixing_machines ~= nil then
     storage.fixing_machines = nil

--- a/nullius/scripts/wind.lua
+++ b/nullius/scripts/wind.lua
@@ -273,7 +273,7 @@ end
 function destroy_wind_mod_entity(unit)
   -- Entity is managed by another mod.  Only destroy collision boxes.
   local entry = storage.nullius_wind_mod_entities[unit]
-  if entry == nil then return end
+  if entry == nil then return false end
 
   for _, cb in ipairs{entry.collision_box, entry.collision_box2, entry.collision_box3, entry.collision_box4} do
     if cb ~= nil and cb.valid then
@@ -281,6 +281,7 @@ function destroy_wind_mod_entity(unit)
     end
   end
   storage.nullius_wind_mod_entities[unit] = nil
+  return true
 end
 
 function remove_wind_mod_entity(entity)
@@ -288,5 +289,5 @@ function remove_wind_mod_entity(entity)
 end
 
 function destroyed_wind_mod_entity(unit)
-  destroy_wind_mod_entity(unit)
+  return destroy_wind_mod_entity(unit)
 end

--- a/nullius/scripts/wind.lua
+++ b/nullius/scripts/wind.lua
@@ -6,6 +6,13 @@
 local multiplier = (settings.startup["nullius-wind-turbine-energy-multiplier"].value / 60)
 local base_wind_power = {1500000*multiplier, 4000000*multiplier, 12000000*multiplier}
 
+-- wind_mod_offsets :: dictionary(str -> {int, int, int, int})
+-- Adjustment {top, bottom, left, right} to bounding box of modded entities.
+-- Adjustment is relative to the bounding box of a wind turbine.
+local wind_mod_offsets = {
+  ["cargo-drone-depot-constant-combinator"] = {0, -1, 0, -1}
+}
+
 function init_wind()
   storage.nullius_wind_orientation = 4
   storage.nullius_wind_factor = 0.7
@@ -29,6 +36,8 @@ function init_wind()
       last_offset = ((i - 1) * 24) / 921.0
     }
   end
+
+  storage.nullius_wind_mod_entities = {}
 end
 
 
@@ -237,4 +246,47 @@ function destroyed_wind_turbine(unit)
   end
   end
   return false
+end
+
+function build_wind_mod_entity(entity)
+  -- Entity is managed by another mod.  Only build collision boxes.
+  local surface = entity.surface
+  local position = entity.position
+  local force = entity.force
+
+  toff, boff, loff, roff = unpack(wind_mod_offsets[entity.name] or {0, 0, 0, 0})
+
+  local collision1 = create_wind_collision(surface, position, force, "horizontal", 14.5 + roff, 16 + boff, 16, 14.5)
+  local collision2 = create_wind_collision(surface, position, force, "vertical", 16 + roff, -14.5 + toff, 14.5, 16)
+  local collision3 = create_wind_collision(surface, position, force, "horizontal", -14.5 + loff, -16 + toff, 16, 14.5)
+  local collision4 = create_wind_collision(surface, position, force, "vertical", -16 + loff, 14.5 + boff, 14.5, 16)
+
+  storage.nullius_wind_mod_entities[entity.unit_number] = {
+    collision_box = collision1,
+    collision_box2 = collision2,
+    collision_box3 = collision3,
+    collision_box4 = collision4,
+    surface = surface.name
+  }
+end
+
+function destroy_wind_mod_entity(unit)
+  -- Entity is managed by another mod.  Only destroy collision boxes.
+  local entry = storage.nullius_wind_mod_entities[unit]
+  if entry == nil then return end
+
+  for _, cb in ipairs{entry.collision_box, entry.collision_box2, entry.collision_box3, entry.collision_box4} do
+    if cb ~= nil and cb.valid then
+      cb.destroy()
+    end
+  end
+  storage.nullius_wind_mod_entities[unit] = nil
+end
+
+function remove_wind_mod_entity(entity)
+  destroy_wind_mod_entity(entity.unit_number)
+end
+
+function destroyed_wind_mod_entity(unit)
+  destroy_wind_mod_entity(unit)
 end


### PR DESCRIPTION
Require cargo drone moorings to be spaced apart from one another and from wind turbines.  This uses the same collision boxes as wind turbines.  A new global variable is added to keep track of the collision boxes, like for wind turbines.