### PR TITLE
Do not change small chest recipe for Renai Transportation

### DIFF
--- a/nullius/clutterpedia.lua
+++ b/nullius/clutterpedia.lua
@@ -221,7 +221,6 @@ end
 if mods["RenaiTransportation"] then
     if settings.startup["RTThrowersSetting"].value then
     clutterpedia["nullius-open-chest"] =                        {name = "OpenContainer",                    tech = "nullius-logistic-ballistics-1"}
-    clutterpedia["nullius-closed-chest"] =                      {name = "wooden-chest",                     tech = "nullius-logistic-ballistics-1"}
     
     clutterpedia["nullius-thrower-1"] =                         {name = "RTThrower-inserter-Item",          tech = "nullius-logistic-ballistics-1"}
     clutterpedia["nullius-thrower-2"] =                         {name = "RTThrower-bob-turbo-inserter-Item",tech = "nullius-logistic-ballistics-5"}


### PR DESCRIPTION
Fix a bug where the normal small chest recipe is replaced by Renai Transportation's close chest recipe.