### PR TITLE
Support Transport_Drones_Meglinge_Fork

### DIFF
--- a/nullius/data-final-fixes.lua
+++ b/nullius/data-final-fixes.lua
@@ -5,6 +5,24 @@ require("prototypes.item.module_limitation")
 require("prototypes.item.box_icons")
 require("legacyMirror")
 
+if mods["Transport_Drones"] or mods["Transport_Drones_Meglinge_Fork"] then
+    local collision_mask_util = require("collision-mask-util")
+
+    -- Mirrored entities should keep the same collision mask as their base entity,
+    -- especially after other mods modify collision layers before legacyMirror runs.
+    for _, type_name in pairs({"assembling-machine", "furnace"}) do
+        for _, prototype in pairs(data.raw[type_name] or {}) do
+            local base_name = string.gsub(prototype.name, "^nullius%-mirror%-", "nullius-", 1)
+            if base_name ~= prototype.name then
+                local base = data.raw[type_name][base_name]
+                if base then
+                    prototype.collision_mask = util.table.deepcopy(collision_mask_util.get_mask(base))
+                end
+            end
+        end
+    end
+end
+
 for _, recipe in pairs(data.raw.recipe) do
     if recipe.GCKI_ignore ~= nil then
         recipe.GCKI_ignore = nil

--- a/nullius/info.json
+++ b/nullius/info.json
@@ -62,6 +62,7 @@
 	"! angelssmelting",
 	
 	"(?) Transport_Drones >= 1.0.16",
+	"(?) Transport_Drones_Meglinge_Fork >= 1.0.26",
 	"(?) Companion_Drones >= 1.0.25",
 	"(?) miniloader >= 1.15.7",
 	"(?) FuelTrainStop >= 1.1.0",

--- a/nullius/prototypes/override_mod.lua
+++ b/nullius/prototypes/override_mod.lua
@@ -1343,7 +1343,7 @@ data.raw.recipe["transport-drone"].ingredients = {
   {type = "item", name = "nullius-car-1", amount = 1},
   {type = "item", name = "arithmetic-combinator", amount = 5},
   {type = "item", name = "programmable-speaker", amount = 2},
-  {type = "item", name = "turbo-filter-inserter", amount = 3}
+  {type = "item", name = "bob-turbo-inserter", amount = 3}
 }
 
 data.raw.item["supply-depot"].order = "nullius-d"

--- a/nullius/prototypes/override_mod.lua
+++ b/nullius/prototypes/override_mod.lua
@@ -1,5 +1,6 @@
 local ICONPATH = "__nullius__/graphics/icons/"
 local ENTITYPATH = "__nullius__/graphics/entity/"
+local has_transport_drones = mods["Transport_Drones"] or mods["Transport_Drones_Meglinge_Fork"]
 
 
 if mods["elevated-rails"] then
@@ -1165,7 +1166,7 @@ data.raw.technology["induction-technology5"].unit = {
 end
 
 
-if mods["Transport_Drones"] then
+if has_transport_drones then
 data.raw["item-subgroup"]["transport-drones"].order = "gd"
 
 data.raw.technology["transport-system"].order = "nullius-dg"
@@ -1831,7 +1832,7 @@ if settings.startup["RTZiplineSetting"].value then
 end
 
 if settings.startup["RTTrainRampSetting"].value then
-  if mods["Transport_Drones"] then
+  if has_transport_drones then
     table.insert(data.raw.technology["transport-drone-capacity-1"].prerequisites,
       "nullius-freight-ballistics-1")
     if settings.startup["RTThrowersSetting"].value then
@@ -2248,7 +2249,7 @@ end
 if (mods["beautiful_bridge_railway"] or
     mods["beautiful_bridge_railway_Cargoships"] or
     mods["beautiful_straight_bridge_railway"]) then
-  if (not mods["Transport_Drones"]) then
+  if (not has_transport_drones) then
     data.raw.technology["nullius-braking-2"].prerequisites[2] = nil
   end
   table.insert(data.raw.technology["nullius-braking-2"].prerequisites,"nullius-rail-bridges")

--- a/nullius/prototypes/override_mod_final.lua
+++ b/nullius/prototypes/override_mod_final.lua
@@ -80,7 +80,9 @@ end
 end
 
 
-if mods["Transport_Drones"] then
+local has_transport_drones = mods["Transport_Drones"] or mods["Transport_Drones_Meglinge_Fork"]
+
+if has_transport_drones then
   for _,recipe in pairs(data.raw.recipe) do
     if (string.sub(recipe.name, 1, 8) == "request-") then
       local product = string.sub(recipe.name, 9, -1)


### PR DESCRIPTION
- Add support for `Transport_Drones_Meglinge_Fork` 
- Adds an optional dependency on `Transport_Drones_Meglinge_Fork` so prototype creation order is correct
- Keeps `nullius-mirror-*` collision masks aligned with their base entities
- Fixes the Transport Drones recipe ingredient to use Bob Logistics 2.0’s `bob-turbo-inserter`.

Most of the changes are fairly straightforward. The collision mask update was the least obvious part to me. As I understand, `legacyMirror` creates mirrored entities after other mods may have changed the base collision masks, which can leave `next_upgrade` chains with mismatched masks. I used some LLM assistance while debugging this, but reviewed and tweaked the diff and tested it locally. It loads and works correctly in my setup.

`Transport_Drones_Meglinge_Fork` appears to be the most active Factorio 2.0 transport drones fork and was the one most recommended on the Nullius Discord, so it seemed like the best compatibility target.