### PR TITLE
mining an entity that is using a battery now returns a discharged battery

### DIFF
--- a/nullius/scripts/build.lua
+++ b/nullius/scripts/build.lua
@@ -47,6 +47,14 @@ function entity_added(entity, handbuilt)
   end
 end
 
+local refundable_burnt_result = { -- what burnt results should be returned if an entity is mined
+	["nullius-uncharged-battery-1"] = true,
+	["nullius-uncharged-battery-2"] = true,
+	["nullius-uncharged-battery-3"] = true,
+	["nullius-canister"] = true,
+	["nullius-water-canister"] = true,
+}
+
 function entity_removed(entity, died, buffer)
   if (string.sub(entity.name, 1, 8) ~= "nullius-") then
     if (entity.type == "constant-combinator" and
@@ -58,7 +66,7 @@ function entity_removed(entity, died, buffer)
   end
   if entity.burner and buffer and entity.burner.currently_burning then
 	local burnt_result = entity.burner.currently_burning.name.burnt_result
-	if burnt_result and (string.sub(burnt_result.name, 1, 26) == "nullius-uncharged-battery-") then
+	if burnt_result and refundable_burnt_result[burnt_result.name] then
 	   buffer.insert({name = burnt_result, count = 1})
 	end
   end

--- a/nullius/scripts/build.lua
+++ b/nullius/scripts/build.lua
@@ -47,7 +47,7 @@ function entity_added(entity, handbuilt)
   end
 end
 
-function entity_removed(entity, died)
+function entity_removed(entity, died, buffer)
   if (string.sub(entity.name, 1, 8) ~= "nullius-") then
     if (entity.type == "constant-combinator" and
         string.sub(entity.name, 1, 12) == "cargo-drone-") then
@@ -55,6 +55,12 @@ function entity_removed(entity, died)
     else
       return
     end
+  end
+  if entity.burner and entity.burner.currently_burning then
+	local burnt_result = entity.burner.currently_burning.name.burnt_result
+	if burnt_result and (string.sub(burnt_result.name, 1, 26) == "nullius-uncharged-battery-") then
+	   buffer.insert({name = burnt_result, count = 1})
+	end
   end
   local suffix = string.sub(entity.name, 9, -2)
   if (suffix == "wind-base-") then
@@ -83,11 +89,11 @@ function entity_raised(event)
   entity_added(event.entity, nil)
 end
 function entity_mined(event)
-  entity_removed(event.entity, false)
+  entity_removed(event.entity, false, event.buffer)
 end
 function entity_died(event)
   if script_kill then return end
-  entity_removed(event.entity, true)
+  entity_removed(event.entity, true, nil)
 end
 function entity_destroyed(event)
   if (script_kill or (event.type ~= defines.target_type.entity)) then return end

--- a/nullius/scripts/build.lua
+++ b/nullius/scripts/build.lua
@@ -56,7 +56,7 @@ function entity_removed(entity, died, buffer)
       return
     end
   end
-  if entity.burner and entity.burner.currently_burning then
+  if entity.burner and buffer and entity.burner.currently_burning then
 	local burnt_result = entity.burner.currently_burning.name.burnt_result
 	if burnt_result and (string.sub(burnt_result.name, 1, 26) == "nullius-uncharged-battery-") then
 	   buffer.insert({name = burnt_result, count = 1})


### PR DESCRIPTION
Works for mining by player and robots. Had to add a reference to buffer inventory to entity_removed(...) arguments.
I haven't tested multi-player.