### PR TITLE
Fix inadvertently disabled recipes

### DIFF
--- a/nullius/changelog.txt
+++ b/nullius/changelog.txt
@@ -6,6 +6,7 @@ Date: xx.xx.2026
     - Added German translation
   Bugfixes:
     - Fixed which recipes enable biology drone remotes
+    - Fix inadvertently disabled recipes from Factorissimo and AAI Signal Transmission
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.9
 Date: 09.06.2026

--- a/nullius/prototypes/mods.lua
+++ b/nullius/prototypes/mods.lua
@@ -164,8 +164,8 @@ data:extend({
       {type = "item", name = "nullius-relay-1", amount = 2}
     },
     results = {
-			{type = "item", name = "aai-signal-sender", amount = 1}
-		},
+      {type = "item", name = "aai-signal-sender", amount = 1}
+    },
     enabled = false
   },
   {
@@ -180,8 +180,8 @@ data:extend({
       {type = "item", name = "programmable-speaker", amount = 2}
     },
     results = {
-			{type = "item", name = "aai-signal-receiver", amount = 1}
-		},
+      {type = "item", name = "aai-signal-receiver", amount = 1}
+    },
     enabled = false
   },
 
@@ -208,6 +208,8 @@ data:extend({
     prerequisites = {"nullius-checkpoint-sensor", "nullius-mass-production-3"}
   }
 })
+data.raw.item["aai-signal-sender"].order = "nullius-z-a"
+data.raw.item["aai-signal-receiver"].order = "nullius-z-b"
 data.raw.roboport["aai-signal-sender"].energy_source.input_flow_limit = "5MW"
 data.raw.roboport["aai-signal-sender"].energy_source.buffer_capacity = "1.2MJ"
 data.raw.roboport["aai-signal-sender"].energy_usage = "2.5MW"
@@ -279,6 +281,16 @@ data:extend({
     enabled = false
   }
 })
+
+for _, item_name in ipairs{"factory-1", "factory-1-instantiated", "factory-2", "factory-2-instantiated",
+                           "factory-3", "factory-3-instantiated", "factory-circuit-connector",
+                           "factory-requester-chest", "factory-input-pipe", "factory-output-pipe",
+                           "factory-circuit-input", "factory-circuit-output"} do
+  local item = data.raw.item[item_name]
+  if item then
+    item.order = "nullius-" .. item.order
+  end
+end
 
 if mods["factorissimo-2-notnotmelon"] then
 data:extend({


### PR DESCRIPTION
Put "nullius" in the order of items from Factorissimo and AAI Signal Transmission
so that recipes will not be disabled.