### PR TITLE
Change the icon of a few technologies to use new 2.0 icons or better match the content.

### DIFF
--- a/nullius/changelog.txt
+++ b/nullius/changelog.txt
@@ -6,6 +6,8 @@ Date: xx.xx.2026
     - Added German translation
     - Deconstructing an entity with a partly consumed canister or battery will now return an empty canister or discharged battery
     - Improve YAFC compatibility with collecting the crashed landing lab and extra milestones
+  Changes:
+    - Update the icons of a few technologies to better match their intent.
   Bugfixes:
     - Fixed which recipes enable biology drone remotes
     - Fix inadvertently disabled recipes from Factorissimo and AAI Signal Transmission

--- a/nullius/prototypes/checkpoint.lua
+++ b/nullius/prototypes/checkpoint.lua
@@ -5,9 +5,8 @@ local function checkmark(scale)
   return {
     icon = ICONPATH .. "checkpoint.png",
     icon_size = 64,
-    
-	tint = {0.6, 0.6, 0.6, 0.6},
-	scale = scale
+    tint = {0.6, 0.6, 0.6, 0.6},
+    scale = scale
   }
 end
 
@@ -315,10 +314,10 @@ data:extend({
         icon_size = 64,
         
       },
-	  {
-	    icon = "__nullius__/graphics/technology/tech_windturbine1.png",
-	    icon_size = 254,
-		scale = 0.5
+	    {
+	      icon = "__nullius__/graphics/technology/tech_windturbine1.png",
+	      icon_size = 254,
+		    scale = 0.5
       }
     },
     unit = {
@@ -345,17 +344,10 @@ data:extend({
     order = "nullius-yc",
     icons = {
       {
-        icon = BASEICON .. "steam-turbine.png",
-        icon_size = 64,
-        
+        icon = "__base__/graphics/technology/steam-power.png",
+        icon_size = 256,
       },
-      {
-        icon = BASEICON .. "fluid/steam.png",
-        icon_size = 64,
-        
-		scale = 1.8,
-		tint = {0.75, 0.75, 0.75, 0.75}
-      }
+      checkmark(2.25)
     },
     unit = {
       count = 1,
@@ -1277,12 +1269,11 @@ data:extend({
 	    {"technology-description.nullius-item", tostring(100), "nullius-battery-1", {"item-name.nullius-battery-1"}}},
     order = "nullius-ye",
     icons = {
-	  {
-        icon = "__base__/graphics/icons/battery-equipment.png",
-        icon_size = 64,
-        
-	  },
-          checkmark(2)
+	    {
+        icon = "__base__/graphics/technology/battery.png",
+        icon_size = 256,  
+	    },
+      checkmark(2)
     },
     unit = {
       count = 1,
@@ -1542,7 +1533,7 @@ data:extend({
     order = "nullius-ye",
     icons = {
       {
-        icon = "__base__/graphics/technology/productivity-module-2.png",
+        icon = "__base__/graphics/technology/productivity-module-1.png",
         icon_size = 256,
         
       },
@@ -1863,7 +1854,6 @@ data:extend({
       {
         icon = BASEICON .. "blueprint.png",
         icon_size = 64,
-        
       },
       {
         icon = ICONPATH .. "android1.png",
@@ -1888,12 +1878,11 @@ data:extend({
 		    "nullius-box-battery-2", {"item-name.nullius-battery-2"}}},
     order = "nullius-yf",
     icons = {
-	  {
-        icon = "__base__/graphics/icons/battery-equipment.png",
-        icon_size = 64,
-        
-	  },
-          checkmark(2)
+      {
+          icon = "__base__/graphics/technology/battery-mk2-equipment.png",
+          icon_size = 256,
+      },
+      checkmark(2)
     },
     unit = {
       count = 1,
@@ -2002,7 +1991,7 @@ data:extend({
   {
     type = "technology",
     name = "nullius-checkpoint-processor-2",
-    localised_name = {"technology-name.nullius-checkpoint", {"technology-name.nullius-utilization",
+    localised_name = {"technology-name.nullius-checkpoint", {"technology-name.nullius-utilization", 
 	    {"item-name.nullius-processor-2"}}},
     localised_description = {"technology-description.nullius-consume",
 	    {"technology-description.nullius-item-boxable", tostring(1000), "nullius-processor-2",
@@ -2014,7 +2003,7 @@ data:extend({
         icon_size = 64
       },
 	  {
-        icon = "__base__/graphics/technology/processing-unit.png",
+        icon = "__base__/graphics/technology/advanced-circuit.png",
         icon_size = 256,
         
 		scale = 0.2

--- a/nullius/prototypes/technology.lua
+++ b/nullius/prototypes/technology.lua
@@ -1145,9 +1145,8 @@ data:extend({
     type = "technology",
     name = "nullius-energy-storage-1",
     order = "nullius-cf",
-    icon_size = 64,
-    
-    icon = "__base__/graphics/icons/steam-turbine.png",
+    icon = "__base__/graphics/technology/steam-power.png",
+    icon_size = 256,
     effects = {
       {
         type = "unlock-recipe",
@@ -1853,7 +1852,7 @@ data:extend({
     type = "technology",
     name = "nullius-electronics-1",
     order = "nullius-cl",
-    icon = "__base__/graphics/technology/electronics.png",
+    icon = "__base__/graphics/technology/advanced-combinators.png",
     icon_size = 256,
     
     effects = {
@@ -2451,7 +2450,7 @@ data:extend({
     type = "technology",
     name = "nullius-mining-2",
     order = "nullius-de",
-    icon = "__base__/graphics/technology/mining-productivity.png",
+    icon = "__base__/graphics/technology/electric-mining-drill.png",
     icon_size = 256,
     
     effects = {
@@ -5765,7 +5764,7 @@ data:extend({
     type = "technology",
     name = "nullius-electronics-2",
     order = "nullius-ei",
-    icon = "__base__/graphics/technology/advanced-circuit.png",
+    icon = "__base__/graphics/technology/electronics.png",
     icon_size = 256,
     
     effects = {
@@ -7133,7 +7132,7 @@ data:extend({
     type = "technology",
     name = "nullius-optimization-4",
     order = "nullius-el",
-    icon = "__base__/graphics/technology/productivity-module-2.png",
+    icon = "__base__/graphics/technology/productivity-module-1.png",
     icon_size = 256,
     
     effects = {
@@ -9664,7 +9663,7 @@ data:extend({
     type = "technology",
     name = "nullius-mining-3",
     order = "nullius-fd",
-    icon = "__base__/graphics/technology/mining-productivity.png",
+    icon = "__base__/graphics/technology/electric-mining-drill.png",
     icon_size = 256,
     
     effects = {
@@ -10786,7 +10785,7 @@ data:extend({
     type = "technology",
     name = "nullius-battery-storage-3",
     order = "nullius-fj",
-    icon = "__base__/graphics/technology/battery.png",
+    icon = "__base__/graphics/technology/battery-mk2-equipment.png",
     icon_size = 256,
     
     effects = {
@@ -11235,7 +11234,7 @@ data:extend({
     type = "technology",
     name = "nullius-electronics-3",
     order = "nullius-fm",
-    icon = "__base__/graphics/technology/processing-unit.png",
+    icon = "__base__/graphics/technology/advanced-circuit.png",
     icon_size = 256,
     
     effects = {
@@ -11932,7 +11931,6 @@ data:extend({
     order = "nullius-fq",
     icon = "__base__/graphics/technology/electronics.png",
     icon_size = 256,
-    
     effects = {
       {
         type = "unlock-recipe",
@@ -13922,7 +13920,7 @@ data:extend({
     type = "technology",
     name = "nullius-miniaturization-2",
     order = "nullius-gg",
-    icon = "__base__/graphics/technology/electronics.png",
+    icon = "__base__/graphics/technology/advanced-circuit.png",
     icon_size = 256,
     
     effects = {


### PR DESCRIPTION
Fixed a few discrepancies that annoyed me:
- module icon with 2 lights when you unlock the productivity module with just 1 light
- processing unit icon for tech and checkpoint when it's about processor 2, which uses advanced circuit
- then realized that processor 1 used the advanced circuit icon
- batteries 2 were using item icon instead of the technology
- new icon for electric mining drill for Mining 2/3 techs (but left mining 1 alone since it used the burner mining drill icon. Maybe this too?)
- new icon for steam power for Energy Storage 1

<img width="613" height="850" alt="image" src="https://github.com/user-attachments/assets/02b36919-865b-4b15-9653-294cdd5957fc" />
<img width="654" height="955" alt="image" src="https://github.com/user-attachments/assets/a8a47b15-b257-477a-bc8b-1120b00a3e93" />
<img width="1075" height="1309" alt="image" src="https://github.com/user-attachments/assets/74e1d728-a09a-439d-91a2-f76f418144ef" />
<img width="1072" height="906" alt="image" src="https://github.com/user-attachments/assets/6310e77a-2d40-4a03-8e10-f06fc8556766" />
<img width="1000" height="687" alt="image" src="https://github.com/user-attachments/assets/28c3ab40-d03e-41c0-8729-614195e9ac93" />
<img width="601" height="313" alt="image" src="https://github.com/user-attachments/assets/eb3447c8-21a1-4a58-8751-1cab68123447" />
