### PR TITLE
Use nickel in checkpoint for Tricky Old Nick mod

### DIFF
--- a/nullius/prototypes/checkpoint.lua
+++ b/nullius/prototypes/checkpoint.lua
@@ -10,6 +10,16 @@ local function checkmark(scale)
   }
 end
 
+local checkpoint_mining_iron = "iron-ore"
+local checkpoint_mining_iron_box = "nullius-box-iron-ore"
+local checkpoint_mining_iron_localised = {"item-name.iron-ore"}
+if mods["tricky-old-nick"] then
+  checkpoint_mining_iron = "nullius-nickel-ore"
+  checkpoint_mining_iron_box = "nullius-box-nickel-ore"
+  checkpoint_mining_iron_localised = {"item-name.nullius-nickel-ore"}
+end
+
+
 data:extend({
   {
     type = "technology",
@@ -1819,7 +1829,7 @@ data:extend({
 	    {"technology-name.nullius-mining"}}},
     localised_description = {"",
 	    {"technology-description.nullius-consume", {"technology-description.nullius-item-boxable",
-		    tostring(1200000),"iron-ore", "nullius-box-iron-ore", {"item-name.iron-ore"}}}, "\n",
+		    tostring(1200000), checkpoint_mining_iron, checkpoint_mining_iron_box, checkpoint_mining_iron_localised}}, "\n",
 	    {"technology-description.nullius-consume", {"technology-description.nullius-item-boxable",
 		    tostring(900000),"nullius-sandstone", "nullius-box-sandstone", {"item-name.nullius-sandstone"}}}, "\n",
 	    {"technology-description.nullius-consume", {"technology-description.nullius-item-boxable",

--- a/nullius/scripts/checkpoint.lua
+++ b/nullius/scripts/checkpoint.lua
@@ -161,6 +161,10 @@ if script.active_mods["lambent-nil"] then
   checkpoint_data["chelating-agent"] = {{ CHK_ITEM, STT_PRODUCE, 1000, {{"nullius-chelating-agent"}} }}
 end
 
+if script.active_mods["tricky-old-nick"] then
+  checkpoint_data["mining"][1][4] = {{"nullius-nickel-ore"}, {"nullius-box-nickel-ore",5}}
+end
+
 
 local broken_data = {
   ["air-filter"] = 3,


### PR DESCRIPTION
Changed the mining utilization checkpoint to require nickel instead of iron when Tricky Old Nick is enabled.  This change is to reduce checkpoint frustration.  It is motivated by feedback from a user whose nickel utilization was much higher than iron upon reaching the checkpoint.