### PR TITLE
Add missing Russian translations for Diesel

### DIFF
--- a/nullius/locale/ru/fluid.cfg
+++ b/nullius/locale/ru/fluid.cfg
@@ -63,6 +63,7 @@ nullius-fatty-acids=Жирные кислоты
 nullius-fatty-acid=Жирная кислота
 nullius-oil=Нефть
 nullius-petroleum=Нефть
+nullius-diesel=Дизель
 nullius-nucleotides=Нуклеотиды
 nullius-nucleotide=Нуклеотид
 nullius-copper-solution=Медный раствор

--- a/nullius/locale/ru/item.cfg
+++ b/nullius/locale/ru/item.cfg
@@ -123,6 +123,7 @@ nullius-textile=Текстиль
 nullius-canister=Пустая канистра
 nullius-hydrogen-canister=Канистра с водородом
 nullius-methanol-canister=Канистра с метанолом
+nullius-diesel-canister=Канистра с дизелем
 nullius-rocket-fuel=Ракетное топливо
 nullius-water-canister=Канистра с водой
 nullius-gas-void=Сброс газа


### PR DESCRIPTION
The diesel feature (PR #89) added fluid-name.nullius-diesel and item-name.nullius-diesel-canister, but the Russian locale was never updated, so both showed as raw keys in game. All other diesel recipes derive their names from these two keys via existing templates (combustion, flushing, boxing), so they are fixed as well.