### PR TITLE
Use SI notation for large numbers in checkpoints

### DIFF
--- a/nullius/changelog.txt
+++ b/nullius/changelog.txt
@@ -12,6 +12,7 @@ Date: xx.xx.2026
   Changes:
     - Update the icons of a few technologies to better match their intent.
     - Large Tank 3 recipe now uses Medium Tank 4 as an ingredient, instead of Underground Pipe 4 box.
+    - Use SI prefixes for large numbers in checkpoint descriptions.
   Bugfixes:
     - Fixed which recipes enable biology drone remotes
     - Fix inadvertently disabled recipes from Factorissimo and AAI Signal Transmission

--- a/nullius/locale/en/tech.cfg
+++ b/nullius/locale/en/tech.cfg
@@ -338,7 +338,7 @@ nullius-fluid=__1__ __3__ ([fluid=__2__])
 nullius-fluid-compressible=__1__ __4__ ([fluid=__2__] or [fluid=__3__])
 nullius-fluid-sequestration=__1__ __4__, directly ([fluid=__2__] or [fluid=__3__]) or via plants ([item=nullius-algae], [item=nullius-grass], or [item=nullius-tree])
 nullius-complete-checkpoint=__1__ completed!
-nullius-toggle-pump=Toggle a pump [item=nullius-pump-1] to a valve
+nullius-toggle-pump=Toggle a pump ([item=nullius-pump-1]) to a valve.
 nullius-display-plates=Representative imagery for concise labeling.
 nullius-insulation=Materials with low electrical or thermal conductivity.
 nullius-rail-bridges=Build rail bridges across bodies of water.

--- a/nullius/prototypes/checkpoint.lua
+++ b/nullius/prototypes/checkpoint.lua
@@ -10,6 +10,23 @@ local function checkmark(scale)
   }
 end
 
+local function round(n)
+  return math.floor(n + 0.5)
+end
+
+local function si_string(n)
+  -- Format number n as a string with an SI prefix.
+  -- The null prefix and k, M, G, and T are used.
+  -- The significand is made less than or equal to 1500, and
+  -- rounded to an integer.  As a special case,
+  -- multiples of 1000 up to 9000 are formatted without a prefix.
+  if n <= 1.5004e3 or (n < 1e4 and n % 1000 == 0) then return tostring(round(n)) end
+  if n <= 1.5004e6 then return tostring(round(n / 1e3)) .. 'k' end
+  if n <= 1.5004e9 then return tostring(round(n / 1e6)) .. 'M' end
+  if n <= 1.5004e12 then return tostring(round(n / 1e9)) .. 'G' end
+  return tostring(round(n / 1e12)) .. 'T'
+end
+
 local checkpoint_mining_iron = "iron-ore"
 local checkpoint_mining_iron_box = "nullius-box-iron-ore"
 local checkpoint_mining_iron_localised = {"item-name.iron-ore"}
@@ -198,7 +215,7 @@ data:extend({
     localised_name = {"technology-name.nullius-checkpoint", {"technology-name.nullius-utilization",
 	    {"fluid-name.nullius-water"}}},
     localised_description = {"technology-description.nullius-consume",
-	    {"technology-description.nullius-fluid", tostring(10000), "nullius-water", {"fluid-name.nullius-water"}}},
+	    {"technology-description.nullius-fluid", si_string(10000), "nullius-water", {"fluid-name.nullius-water"}}},
     order = "nullius-yc",
     icons = {
       {
@@ -1102,7 +1119,7 @@ data:extend({
     localised_name = {"technology-name.nullius-checkpoint", {"technology-name.nullius-utilization",
 	    {"fluid-name.nullius-propene"}}},
     localised_description = {"technology-description.nullius-consume",
-	    {"technology-description.nullius-fluid", tostring(300000), "nullius-propene", {"fluid-name.nullius-propene"}}},
+	    {"technology-description.nullius-fluid", si_string(300000), "nullius-propene", {"fluid-name.nullius-propene"}}},
     order = "nullius-ye",
     icons = {
       {
@@ -1197,7 +1214,7 @@ data:extend({
     localised_name = {"technology-name.nullius-checkpoint", {"technology-name.nullius-utilization",
 	    {"item-name.nullius-crushed-iron-ore"}}},
     localised_description = {"technology-description.nullius-consume",
-	    {"technology-description.nullius-item", tostring(40000), "nullius-crushed-iron-ore", {"item-name.nullius-crushed-iron-ore"}}},
+	    {"technology-description.nullius-item", si_string(40000), "nullius-crushed-iron-ore", {"item-name.nullius-crushed-iron-ore"}}},
     order = "nullius-ye",
     icons = {
       {
@@ -1224,7 +1241,7 @@ data:extend({
     localised_name = {"technology-name.nullius-checkpoint", {"technology-name.nullius-utilization",
 	    {"item-name.nullius-aluminum-carbide"}}},
     localised_description = {"technology-description.nullius-consume",
-	    {"technology-description.nullius-item", tostring(40000), "nullius-aluminum-carbide", {"item-name.nullius-aluminum-carbide"}}},
+	    {"technology-description.nullius-item", si_string(40000), "nullius-aluminum-carbide", {"item-name.nullius-aluminum-carbide"}}},
     order = "nullius-ye",
     icons = {
       {
@@ -1666,7 +1683,7 @@ data:extend({
     localised_name = {"technology-name.nullius-checkpoint", {"technology-name.nullius-utilization",
 	    {"fluid-name.nullius-benzene"}}},
     localised_description = {"technology-description.nullius-consume",
-	    {"technology-description.nullius-fluid", tostring(800000), "nullius-benzene", {"fluid-name.nullius-benzene"}}},
+	    {"technology-description.nullius-fluid", si_string(800000), "nullius-benzene", {"fluid-name.nullius-benzene"}}},
     order = "nullius-ye",
     icons = {
       {
@@ -1829,13 +1846,13 @@ data:extend({
 	    {"technology-name.nullius-mining"}}},
     localised_description = {"",
 	    {"technology-description.nullius-consume", {"technology-description.nullius-item-boxable",
-		    tostring(1200000), checkpoint_mining_iron, checkpoint_mining_iron_box, checkpoint_mining_iron_localised}}, "\n",
+		    si_string(1200000), checkpoint_mining_iron, checkpoint_mining_iron_box, checkpoint_mining_iron_localised}}, "\n",
 	    {"technology-description.nullius-consume", {"technology-description.nullius-item-boxable",
-		    tostring(900000),"nullius-sandstone", "nullius-box-sandstone", {"item-name.nullius-sandstone"}}}, "\n",
+		    si_string(900000),"nullius-sandstone", "nullius-box-sandstone", {"item-name.nullius-sandstone"}}}, "\n",
 	    {"technology-description.nullius-consume", {"technology-description.nullius-item-boxable",
-		    tostring(600000),"nullius-bauxite", "nullius-box-bauxite", {"item-name.nullius-bauxite"}}}, "\n",
+		    si_string(600000),"nullius-bauxite", "nullius-box-bauxite", {"item-name.nullius-bauxite"}}}, "\n",
 	    {"technology-description.nullius-consume", {"technology-description.nullius-item-boxable",
-		    tostring(300000),"nullius-limestone", "nullius-box-limestone", {"item-name.nullius-limestone"}}}},			
+		    si_string(300000),"nullius-limestone", "nullius-box-limestone", {"item-name.nullius-limestone"}}}},
     order = "nullius-yf",
     icons = {
 	  {
@@ -2412,7 +2429,7 @@ data:extend({
     localised_name = {"technology-name.nullius-checkpoint", {"technology-name.nullius-utilization",
 	    {"item-name.nullius-wood"}}},
     localised_description = {"technology-description.nullius-consume",
-	    {"technology-description.nullius-item-boxable", tostring(500000), "nullius-wood",
+	    {"technology-description.nullius-item-boxable", si_string(500000), "nullius-wood",
 		    "nullius-box-wood", {"item-name.nullius-wood"}}},
     order = "nullius-yg",
     icons = {
@@ -2631,10 +2648,10 @@ data:extend({
     localised_description = {"",
 	    {"technology-description.nullius-consume",
 		    {"technology-description.nullius-fluid-sequestration",
-		        tostring(1500000000),"nullius-carbon-dioxide", "nullius-compressed-carbon-dioxide",
+		        si_string(1500000000),"nullius-carbon-dioxide", "nullius-compressed-carbon-dioxide",
 			        {"fluid-name.nullius-carbon-dioxide"}}},"\n",
 	    {"technology-description.nullius-produce", {"technology-description.nullius-fluid-compressible",
-		    tostring(2000000000),"nullius-oxygen", "nullius-compressed-oxygen", {"fluid-name.nullius-oxygen"}}}},
+		    si_string(2000000000),"nullius-oxygen", "nullius-compressed-oxygen", {"fluid-name.nullius-oxygen"}}}},
     order = "nullius-yg",
     icons = {
       {

--- a/nullius/prototypes/checkpoint.lua
+++ b/nullius/prototypes/checkpoint.lua
@@ -19,7 +19,7 @@ local function si_string(n)
   -- The null prefix and k, M, G, and T are used.
   -- The significand is made less than or equal to 1500, and
   -- rounded to an integer.  As a special case,
-  -- multiples of 1000 up to 9000 are formatted without a prefix.
+  -- multiples of 1000 up to 9000 are formatted without a suffix.
   if n <= 1.5004e3 or (n < 1e4 and n % 1000 == 0) then return tostring(round(n)) end
   if n <= 1.5004e6 then return tostring(round(n / 1e3)) .. 'k' end
   if n <= 1.5004e9 then return tostring(round(n / 1e6)) .. 'M' end


### PR DESCRIPTION
This change uses SI prefixes for large numbers in checkpoint descriptions.

Also made English formatting consistent in a checkpoint description.