### PR TITLE
Give drone launchers a single larger ammo slot instead of several

### DIFF
--- a/nullius/changelog.txt
+++ b/nullius/changelog.txt
@@ -6,6 +6,7 @@ Date: xx.xx.2026
   Changes:
     - Compressors and large furnaces can now be flipped, mirroring their diagonal pipes.
     - Added requirement to store hydrogen for the energy storage checkpoint
+    - Drone launchers now have a single drone slot with a larger capacity, instead of several slots that could mislead into loading multiple drone types (only one type can ever be fired).
   Modding:
     - Support for Display Plates Forked mod
     - Support for companion-drones-mjlfix mod

--- a/nullius/prototypes/entity/drone.lua
+++ b/nullius/prototypes/entity/drone.lua
@@ -10,8 +10,9 @@ data:extend({
     icons = data.raw.item["nullius-drone-launcher-1"].icons,
     flags = {"placeable-neutral", "placeable-player", "player-creation"},
     collision_mask = collision_mask_util.get_default_mask("rocket-silo"),
-    inventory_size = 3,
-    ammo_stack_limit = 10,
+    -- Single slot, since the engine only ever fires the first drone type loaded
+    inventory_size = 1,
+    ammo_stack_limit = 30,
     automated_ammo_count = 10,
     alert_when_attacking = false,
     minable = {mining_time = 1.5, result = "nullius-drone-launcher-1"},
@@ -90,8 +91,9 @@ data:extend({
     icons = data.raw.item["nullius-drone-launcher-2"].icons,
     flags = {"placeable-neutral", "placeable-player", "player-creation"},
     collision_mask = collision_mask_util.get_default_mask("rocket-silo"),
-    inventory_size = 5,
-    ammo_stack_limit = 10,
+    -- Single slot, since the engine only ever fires the first drone type loaded
+    inventory_size = 1,
+    ammo_stack_limit = 50,
     automated_ammo_count = 10,
     alert_when_attacking = false,
     minable = {mining_time = 2, result = "nullius-drone-launcher-2"},


### PR DESCRIPTION
Drone launchers have several drone slots, but the engine only ever fires the first ammo type a turret holds and says "no ammo" for another -  this confused me a lot in my play.
It looks like an engine limitation with no mod-side workaround, so the fix is to stop offering slots that can't be used.

Change:
`inventory_size = 1` with a raised `ammo_stack_limit` (30 / 50), so one slot holds what all the slots used to — the same pattern vanilla uses for the artillery turret (15 shells in one slot, stack size 1).
Capacity is unchanged for 10-stack drones; 5-stack drones gain some, since `ammo_stack_limit` is flat and can't vary per drone type.

Migration:
Tested, a launcher holding one drone type keeps all of them; a launcher holding several keeps the first type and loses the rest.