### PR TITLE
If playing seablock, allow deepwater terraform

### DIFF
--- a/nullius/scripts/drone.lua
+++ b/nullius/scripts/drone.lua
@@ -117,6 +117,9 @@ function terraform_score(name)
   elseif (string.sub(name, 1, 9) == "volcanic-") then
     return 2
   end
+  if script.active_mods["blockius"] and (string.sub(name, 1, 9) == "deepwater") then
+	return 0.25 
+  end
   return 0
 end
 


### PR DESCRIPTION
Add option for deepwater to give terraform score if playing with a seablock style mod.