### PR TITLE
train-upgrader update

### DIFF
--- a/train-upgrader/changelog.txt
+++ b/train-upgrader/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.0.1
+Date: ????
+  Bugfixes:
+    - Fix group and interrrupt deletion
+  Features:
+    - Add cybersyn 2 support
+    - Add interrupt handling while upgrading trains
+---------------------------------------------------------------------------------------------------
 Version: 2.0.0
 Date: 18.12.2025
   Features:

--- a/train-upgrader/control.lua
+++ b/train-upgrader/control.lua
@@ -3,3 +3,29 @@ require("scripts.station")
 require("scripts.build")
 require("scripts.upgrade")
 require("scripts.tick")
+
+---@namespace train-upgrader
+
+---@class pending
+---@field train train_id
+---@field tick MapTick
+---@field current uint32
+---@field group string
+
+---@class entry
+---@field stop LuaEntity
+---@field units table<integer,LuaEntity>
+---@field suppliers table
+---@field receivers table
+---@field train_count integer
+---@field train_index integer
+---@field last_refresh integer
+---@field hold boolean
+---@field pending table<integer,pending>
+---@field next entry
+---@field prev entry
+
+---@class Storage
+---@field unit_table table<uint64,any>
+---@field station_head entry
+

--- a/train-upgrader/info.json
+++ b/train-upgrader/info.json
@@ -1,6 +1,6 @@
 {
   "name": "train-upgrader",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "factorio_version": "2.0",
   "title": "Train Upgrader",
   "author": "Anachrony",

--- a/train-upgrader/prototypes/entity.lua
+++ b/train-upgrader/prototypes/entity.lua
@@ -25,13 +25,29 @@ supplier.picture = { layers = {
     scale = 0.5
   }
 }}
+supplier.radius_visualisation_specification = {
+  sprite = {
+    filename = "__base__/graphics/entity/beacon/beacon-radius-visualization.png",
+    size = 10,
+  },
+  distance = 2,
+}
 
 local receiver = util.table.deepcopy(supplier)
 receiver.name = "tu-receiver"
 receiver.icons = data.raw.item["tu-receiver"].icons
+assert(receiver.minable)
 receiver.minable.result = "tu-receiver"
 receiver.inventory_size = 40
-receiver.picture.layers[1].filename =
+---@diagnostic disable-next-line: need-check-nil
+receiver.picture.layers[1].filename = 
     "__train-upgrader__/graphics/entity/receiver.png"
-
+receiver.radius_visualisation_specification = {
+  sprite = {
+    filename = "__base__/graphics/entity/beacon/beacon-radius-visualization.png",
+    size = 10,
+  },
+  distance = 2.4,
+}
+    
 data:extend({ supplier, receiver })

--- a/train-upgrader/prototypes/item.lua
+++ b/train-upgrader/prototypes/item.lua
@@ -6,7 +6,7 @@ data:extend({
       icon = "__train-upgrader__/graphics/icon/supplier.png",
       icon_size = 64
     }},
-	  subgroup = "train-transport",
+    subgroup = "train-transport",
     order = "a[train-system]-tub[tu-supplier]",
     place_result = "tu-supplier",
     stack_size = 20
@@ -18,7 +18,7 @@ data:extend({
       icon = "__train-upgrader__/graphics/icon/receiver.png",
       icon_size = 64
     }},
-	  subgroup = "train-transport",
+    subgroup = "train-transport",
     order = "a[train-system]-tuc[tu-receiver]",
     place_result = "tu-receiver",
     stack_size = 20

--- a/train-upgrader/prototypes/override.lua
+++ b/train-upgrader/prototypes/override.lua
@@ -1,4 +1,5 @@
 if mods["nullius"] then
+  ---@diagnostic disable-next-line: param-type-mismatch
   table.insert(data.raw.technology["nullius-distribution-3"].prerequisites,
       "tu-rail-modernization")
 end

--- a/train-upgrader/scripts/build.lua
+++ b/train-upgrader/scripts/build.lua
@@ -1,101 +1,120 @@
-function scan_stop(ts)
-  local chests = ts.surface.find_entities_filtered{area = entity_box(ts, 2.9),
-      type = "container", name = {"tu-supplier", "tu-receiver"}}
-  if ((chests == nil) or (chests[1] == nil)) then return end
+local Station = require("scripts.station")
 
-  if (storage.unit_table == nil) then
-    storage.unit_table = { }
-  else
-    local entry = storage.unit_table[ts.unit_number]
-	if (entry ~= nil) then
-	  delete_station(entry)
-	end  
+---@namespace train-upgrader
+---@type Storage
+storage = storage --[[@as Storage]]
+
+local Build = {}
+
+local function entity_box(entity, dist)
+  local x = entity.position.x
+  local y = entity.position.y
+  return { { x - dist, y - dist }, { x + dist, y + dist } }
+end
+
+---@param train_stop LuaEntity Trainstop
+local function scan_stop(train_stop)
+  local chests = train_stop.surface.find_entities_filtered({
+    area = entity_box(train_stop, 2.9),
+    type = "container",
+    name = { "tu-supplier", "tu-receiver" },
+  })
+  if chests == nil or chests[1] == nil then
+    return
   end
 
-  local unit_list = { }
+  if storage.unit_table == nil then
+    storage.unit_table = {}
+  else
+    local entry = storage.unit_table[train_stop.unit_number]
+    if entry ~= nil then
+      Station.delete_station(entry)
+    end
+  end
+
+  local unit_list = {}
   for _, chest in pairs(chests) do
-    if (chest.valid) then
+    if chest.valid then
       local entry = storage.unit_table[chest.unit_number]
-	  if (entry == nil) then
-	    unit_list[chest.unit_number] = chest
-	  end
-	end
+      if entry == nil then
+        unit_list[chest.unit_number] = chest
+      end
+    end
   end
 
   local supplier_number = 0
-  local supplier_list = { }
+  local supplier_list = {}
   local receiver_number = 0
-  local receiver_list = { }
+  local receiver_list = {}
   for _, e in pairs(unit_list) do
-    if (e.name == "tu-supplier") then
-	  supplier_number = supplier_number + 1
-	  supplier_list[supplier_number] = e
-	elseif (e.name == "tu-receiver") then
-	  receiver_number = receiver_number + 1
-	  receiver_list[receiver_number] = e
-	end
+    if e.name == "tu-supplier" then
+      supplier_number = supplier_number + 1
+      supplier_list[supplier_number] = e
+    elseif e.name == "tu-receiver" then
+      receiver_number = receiver_number + 1
+      receiver_list[receiver_number] = e
+    end
   end
 
-  if ((supplier_number < 1) or (receiver_number < 1)) then return end
-  script.register_on_object_destroyed(ts)
-  init_station(ts, unit_list, supplier_list, receiver_list)
+  if supplier_number < 1 or receiver_number < 1 then
+    return
+  end
+  script.register_on_object_destroyed(train_stop)
+  Station.init_station(train_stop, unit_list, supplier_list, receiver_list)
 end
 
-
-function entity_box(entity, dist)
-  local x = entity.position.x
-  local y = entity.position.y
-  return {{x - dist, y - dist}, {x + dist, y + dist}}
-end
-
-function entity_added(entity)
-  if (entity.type == "train-stop") then
+local function entity_added(entity)
+  if entity.type == "train-stop" then
     scan_stop(entity)
-  elseif (string.sub(entity.name, 1, 3) == "tu-") then
+  elseif string.sub(entity.name, 1, 3) == "tu-" then
     script.register_on_object_destroyed(entity)
-    local stops = entity.surface.find_entities_filtered{type = "train-stop",
-	    area = entity_box(entity, 2.9)}
-    if ((stops == nil) or (stops[2] ~= nil)) then return end
+    local stops = entity.surface.find_entities_filtered({ type = "train-stop", area = entity_box(entity, 2.9) })
+    if stops == nil or stops[2] ~= nil then
+      return
+    end
     local ts = stops[1]
-    if ((ts == nil) or (not ts.valid)) then return end
+    if ts == nil or not ts.valid then
+      return
+    end
     scan_stop(ts)
   end
 end
 
-
-function destroy_station(station, unit)
-  if (station == nil) then return end
+function Build.destroy_station(station, unit)
+  if station == nil then
+    return
+  end
   local ts = station.stop
   local kill_stop = ((not ts.valid) or (ts.unit_number == unit))
-  delete_station(station, kill_stop)
-  if (kill_stop) then return end
+  Station.delete_station(station, kill_stop)
+  if kill_stop then
+    return
+  end
   scan_stop(ts)
 end
 
-function destroy_unit(unit)
-  if (storage.unit_table == nil) then return end
-  destroy_station(storage.unit_table[unit], unit)
+local function destroy_unit(unit)
+  if storage.unit_table == nil then
+    return
+  end
+  Build.destroy_station(storage.unit_table[unit], unit)
 end
 
-
-function entity_built(event)
+local function entity_built(event)
   entity_added(event.entity)
 end
-function entity_raised(event)
+
+local function entity_raised(event)
   entity_added(event.entity)
 end
 
-script.on_event(defines.events.on_built_entity, entity_built)
-script.on_event(defines.events.on_robot_built_entity, entity_built)
-script.on_event(defines.events.script_raised_revive, entity_raised)
-
-
-function entity_removed(event)
-  if (string.sub(event.entity.name, 1, 3) == "tu-") then
+local function entity_removed(event)
+  if string.sub(event.entity.name, 1, 3) == "tu-" then
     destroy_unit(event.entity.unit_number)
   end
 end
-function entity_destroyed(event)
+
+local function entity_destroyed(event)
   destroy_unit(event.unit_number)
 end
 
@@ -103,3 +122,9 @@ script.on_event(defines.events.on_player_mined_entity, entity_removed)
 script.on_event(defines.events.on_robot_mined_entity, entity_removed)
 script.on_event(defines.events.on_entity_died, entity_removed)
 script.on_event(defines.events.on_object_destroyed, entity_destroyed)
+
+script.on_event(defines.events.on_built_entity, entity_built)
+script.on_event(defines.events.on_robot_built_entity, entity_built)
+script.on_event(defines.events.script_raised_revive, entity_raised)
+
+return Build

--- a/train-upgrader/scripts/init.lua
+++ b/train-upgrader/scripts/init.lua
@@ -1,6 +1,6 @@
 function init_tu()
-  if (remote.interfaces["PickerDollies"] and
-      remote.interfaces["PickerDollies"]["add_blacklist_name"]) then
+  if remote.interfaces["PickerDollies"] and
+      remote.interfaces["PickerDollies"]["add_blacklist_name"] then
     remote.call("PickerDollies", "add_blacklist_name", "tu-supplier")
     remote.call("PickerDollies", "add_blacklist_name", "tu-receiver")
   end

--- a/train-upgrader/scripts/station.lua
+++ b/train-upgrader/scripts/station.lua
@@ -1,140 +1,185 @@
-function special_stop(stop)
+---@namespace train-upgrader
+---@type Storage
+storage = storage --[[@as Storage]]
+
+local Station = {}
+
+function Station.special_stop(stop)
   local conds = stop.wait_conditions
-  if (conds == nil) then return false end
+  if conds == nil then
+    return false
+  end
   local wc = conds[1]
-  if ((wc == nil) or (conds[2] ~= nil)) then return false end
-  if (wc.type ~= "time") then return false end
-  if (wc.compare_type ~= "and") then return false end
-  if (wc.ticks ~= 36007) then return false end
+  if wc == nil or conds[2] ~= nil then
+    return false
+  end
+  if wc.type ~= "time" then
+    return false
+  end
+  if wc.compare_type ~= "and" then
+    return false
+  end
+  if wc.ticks ~= 36007 then
+    return false
+  end
   return true
 end
 
-function insert_train_schedule(train, station, cs_train)
-  if ((not train.valid) or train.manual_mode) then return false end
-  local sched = train.schedule
-  if (sched == nil) then return false end
-  local stop_name = station.stop.backer_name
-  local hi = -1
-  for i,r in pairs(sched.records) do
-    if (i > hi) then hi = i end
-    if (special_stop(r)) then return false end
+---@param train LuaTrain
+---@param station any
+---@param cs_train any
+---@return any
+function Station.insert_train_schedule(train, station, cs_train)
+  if not train.valid or train.manual_mode then
+    return false
   end
+  local sched = train.get_schedule()
+  local stop_name = station.stop.backer_name
 
-  local ind = hi + 1
-  sched.records[ind] = { station = stop_name,
-      wait_conditions = {{type="time", compare_type="and", ticks=36007}} }
-  if cs_train then
-    remote.call("cybersyn", "remove_train", train.id)
-    if not cs_train.use_any_depot then
-      table.insert(
-        sched.records, 1,
-        remote.call("cybersyn", "create_direct_to_station_order", train.station)
-      )
-      ind = 3
+  for _, r in pairs(sched.get_records()--[[@cast -?]]) do
+    if Station.special_stop(r) then
+      return false
     end
   end
+
+  -- save and remove group, so only one train get summoned
+  local group = train.group
+  train.group = ""
+
+  -- add TU station record to schedule, specific amount of ticks act as indicator
+  local go_ind = sched.add_record({
+    station = stop_name,
+    wait_conditions = { { type = "time", compare_type = "and", ticks = 36007 } },
+  })
+  if cs_train and cs_train ~= "cs2" then
+    remote.call("cybersyn", "remove_train", train.id)
+    if not cs_train.use_any_depot then
+      local record = remote.call("cybersyn", "create_direct_to_station_order", train.station)
+      ---@cast record AddRecordData
+      go_ind = sched.add_record(record)
+    end
+  elseif cs_train and cs_train == "cs2" then
+    -- if I remove the group in general, cs2 doesn't need furter special treatment?!
+    -- train.group = ""
+  end
+
   station.pending[train.id] = {
     train = train,
     tick = game.tick,
-	current = sched.current
+    current = sched.current,
+    group = group
   }
-  train.schedule = sched
-  train.go_to_station(ind)
-  if (train.valid and (train.state == defines.train_state.no_path)) then
-    release_train_schedule(train, station)
+
+  if go_ind ~= nil then
+    sched.go_to_station(go_ind)
+  end
+  -- something went wrong
+  if (train.valid and train.state == defines.train_state.no_path) or go_ind == nil then
+    train.group = group
+    Station.release_train_schedule(train, station)
   end
   return true
 end
 
-function release_train_schedule(train, station)
-  if ((train == nil) or (not train.valid)) then return end
+---@param train LuaTrain
+---@param station entry
+function Station.release_train_schedule(train, station)
+  if train == nil or not train.valid then
+    return
+  end
   local pending = station.pending[train.id]
   station.pending[train.id] = nil
-  local sched = train.schedule
+  local sched = train.get_schedule()
   local name = nil
-  if (station.stop.valid) then
+  local hi = sched.get_record_count()
+  ---@cast hi -?
+  if station.stop.valid then
     name = station.stop.backer_name
   end
   local found = nil
-  local hi = -1
-  for i,r in pairs(sched.records) do
-    if (i > hi) then hi = i end
-    if (((r.station == name) or (name == nil)) and special_stop(r)) then
-	  found = i
-	end
+  if hi == nil then
+    return
+  end
+  for i, r in pairs(sched.get_records() or {}) do
+    if (r.station == name or name == nil) and Station.special_stop(r) then
+      found = i
+    end
   end
 
-  if ((found == nil) or (hi < found)) then return end
-  if (found < hi) then
-    for i = found,(hi - 1) do 
-	  sched.records[i] = sched.records[i + 1]
-	end
+  if found == nil then
+    return
+  else 
+    sched.remove_record({ schedule_index = found }--[[@as ScheduleRecordPosition]])
   end
-
-  sched.records[hi] = nil
-  if (pending ~= nil) then
-    sched.current = pending.current
+  
+  if pending ~= nil then
+    train.group = pending.group
+    sched.go_to_station(pending.current)
   end
-  if (sched.current >= hi) then
-    sched.current = 1
-  end
-  train.schedule = sched
   train.manual_mode = false
 end
 
-
-function init_station(entity, unit_list, supplier_list, receiver_list)
+function Station.init_station(entity, unit_list, supplier_list, receiver_list)
   unit_list[entity.unit_number] = entity
-  local entry = { stop = entity, units = unit_list,
-      suppliers = supplier_list, receivers = receiver_list,
-	  train_count = 0, train_index = 0, last_refresh = 0,
-	  hold = false, pending = { } }
+  local entry = {
+    stop = entity,
+    units = unit_list,
+    suppliers = supplier_list,
+    receivers = receiver_list,
+    train_count = 0,
+    train_index = 0,
+    last_refresh = 0,
+    hold = false,
+    pending = {},
+  }
   for u, _ in pairs(unit_list) do
     storage.unit_table[u] = entry
-  end 
+  end
 
-  if (storage.station_head == nil) then
+  if storage.station_head == nil then
     entry.next = entry
-	  entry.prev = entry
-	  storage.station_head = entry
+    entry.prev = entry
+    storage.station_head = entry
   else
     entry.prev = storage.station_head
-	  entry.next = entry.prev.next
-	  entry.prev.next = entry
-	  entry.next.prev = entry
+    entry.next = entry.prev.next
+    entry.prev.next = entry
+    entry.next.prev = entry
   end
 
   --local stops = entity.force.get_train_stops{name = entity.backer_name}
-  local stops = game.train_manager.get_train_stops{force = entity.force, station_name = entity.backer_name}
-  
-  if (stops[2] ~= nil) then
+  local stops = game.train_manager.get_train_stops({ force = entity.force, station_name = entity.backer_name })
+
+  if stops[2] ~= nil then
     entry.old_name = entity.backer_name
-	  entity.backer_name = "Train_Updater_" .. entity.unit_number
+    entity.backer_name = "Train_Updater_" .. entity.unit_number
   end
 end
 
-function delete_station(station, no_rename)
-  if (station.next == station) then
+function Station.delete_station(station, no_rename)
+  if station.next == station then
     storage.station_head = nil
-  else
+  elseif station.next ~= nil and station.prev ~= nil then
+    
     station.next.prev = station.prev
-	station.prev.next = station.next
-	if (storage.station_head == station) then
-	  storage.station_head = station.next
-	end
+    station.prev.next = station.next
+    if storage.station_head == station then
+      storage.station_head = station.next
+    end
   end
   station.next = nil
   station.prev = nil
 
   for _, pend in pairs(station.pending) do
-    release_train_schedule(pend.train, station)
+    Station.release_train_schedule(pend.train, station)
   end
   for unit, entity in pairs(station.units) do
     storage.unit_table[unit] = nil
   end
 
-  if ((station.old_name ~= nil) and (not no_rename) and
-      station.stop.valid) then
+  if station.old_name ~= nil and not no_rename and station.stop.valid then
     station.stop.backer_name = station.old_name
   end
 end
+
+return Station

--- a/train-upgrader/scripts/tick.lua
+++ b/train-upgrader/scripts/tick.lua
@@ -1,39 +1,51 @@
-function validate_station(station)
-  if (not station.stop.valid) then
-    destroy_station(station, nil)
+local Station = require("scripts.station")
+local Upgrade = require("scripts.upgrade")
+local Build = require("scripts.build")
+
+---@namespace train-upgrader
+---@type Storage
+storage = storage --[[@as Storage]]
+
+local function validate_station(station)
+  if not station.stop.valid then
+    Build.destroy_station(station, nil)
   end
   for u, e in pairs(station.units) do
-    if (not e.valid) then
-	  destroy_station(station, u)
-	  return true
-	end
+    if not e.valid then
+      Build.destroy_station(station, u)
+      return true
+    end
   end
   return false
 end
 
-function check_stopped(station)
+local function check_stopped(station)
   local train = station.stop.get_stopped_train()
-  if ((train == nil) or (not train.valid)) then return false end
-  if (not upgrade_any_carriage(train, station, true)) then
-    release_train_schedule(train, station)
+  if train == nil or not train.valid then
+    return false
+  end
+  if not Upgrade.upgrade_any_carriage(train, station, true) then
+    Station.release_train_schedule(train, station)
   end
   return true
 end
 
-function check_pending(station)
+local function check_pending(station)
   local count = 0
   local tick = 0
   for u, p in pairs(station.pending) do
-    if (not p.train.valid) then
-	  station.pending[u] = nil
-	  return true
-	end
-	if (p.train.state == defines.train_state.no_path) then
-	  release_train_schedule(p.train, station)
-	  return true
-	end
-	count = count + 1
-	if (p.tick > tick) then tick = p.tick end
+    if not p.train.valid then
+      station.pending[u] = nil
+      return true
+    end
+    if p.train.state == defines.train_state.no_path then
+      Station.release_train_schedule(p.train, station)
+      return true
+    end
+    count = count + 1
+    if p.tick > tick then
+      tick = p.tick
+    end
   end
 
   station.pending_count = count
@@ -41,62 +53,103 @@ function check_pending(station)
   return false
 end
 
-function summon_train(station)
+local function summon_train(station)
   local train = station.train_set[station.train_index]
-  if ((not train.valid) or train.manual_mode) then return end
+  if not train.valid or train.manual_mode then
+    return
+  end
+
+  -- check for cybersyn
   local cs_train = nil
   if remote.interfaces["cybersyn"] then
     cs_train = remote.call("cybersyn", "read_global", "trains", train.id)
-    if cs_train and cs_train.status ~= 0 then return end
+    if cs_train and cs_train.status ~= 0 then
+      return
+    end
   end
-  if (not upgrade_any_carriage(train, station, false)) then return end
 
-  if (station.last_summon > 0) then
+  -- check for cybersyn2
+  if remote.interfaces["cybersyn2"] then
+    if string.match ( train.group ,"[virtual-signal=cybersyn2]" ) ~= nil  then
+      local result = remote.call("cybersyn2", "query", {type = "vehicles" ,luatrain_ids = {train.id}})
+      if result and result.data and result.data[1].delivery_id == nil then
+        cs_train = "cs2"
+      else 
+        return
+      end
+      
+    end
+  end
+
+  if not Upgrade.upgrade_any_carriage(train, station, false) then
+    return
+  end
+
+  if station.last_summon > 0 then
     local delay_table = { 360, 1200, 3600 }
     local delay = delay_table[station.pending_count]
-	station.hold = true
-	if (delay == nil) then return end
-	if (game.tick < (station.last_summon + delay)) then return end
-	local tsl = station.stop.trains_limit
-	if ((tsl ~= nil) and (station.pending_count >= tsl)) then return end
-	station.hold = false
+    station.hold = true
+    if delay == nil then
+      return
+    end
+    if game.tick < (station.last_summon + delay) then
+      return
+    end
+    local limit = station.stop.trains_limit
+    if limit ~= nil and (station.pending_count >= limit) then
+      return
+    end
+    station.hold = false
   end
-  insert_train_schedule(train, station, cs_train)
+  Station.insert_train_schedule(train, station, cs_train)
 end
 
-function update_train_set(station)
-  if (station.hold) then
+local function update_train_set(station)
+  if station.hold then
     station.hold = false
     return false
   end
 
   station.train_index = station.train_index + 1
-  if (station.train_index <= station.train_count) then return false end
-  if (game.tick < (station.last_refresh + 900)) then return true end
-  --station.train_set = station.stop.surface.get_trains(station.stop.force)
-  station.train_set = game.train_manager.get_trains{force = station.stop.force, surface = station.stop.surface}
+  if station.train_index <= station.train_count then
+    return false
+  end
+  if game.tick < (station.last_refresh + 900) then
+    return true
+  end
+  station.train_set = game.train_manager.get_trains({ force = station.stop.force, surface = station.stop.surface })
   station.train_index = 0
   station.train_count = 0
   station.last_refresh = game.tick
 
-  if (station.train_set ~= nil) then
-	while (station.train_set[station.train_count + 1] ~= nil) do
-	  station.train_count = station.train_count + 1
-	end
+  if station.train_set ~= nil then
+    while station.train_set[station.train_count + 1] ~= nil do
+      station.train_count = station.train_count + 1
+    end
   end
   return true
 end
 
-function update_station(station)
-  if (validate_station(station)) then return end
-  if (check_stopped(station)) then return end
-  if (check_pending(station)) then return end
-  if (update_train_set(station)) then return end
+local function update_station(station)
+  if validate_station(station) then
+    return
+  end
+  if check_stopped(station) then
+    return
+  end
+  if check_pending(station) then
+    return
+  end
+  if update_train_set(station) then
+    return
+  end
   summon_train(station)
 end
 
-function update_tick()
-  if (storage.station_head == nil) then return end
+local function update_tick()
+  if storage.station_head == nil then
+    return
+  end
   storage.station_head = storage.station_head.next
   update_station(storage.station_head)
 end

--- a/train-upgrader/scripts/upgrade.lua
+++ b/train-upgrader/scripts/upgrade.lua
@@ -1,282 +1,329 @@
-carriage_inventories = {
+local Station = require("scripts.station")
+
+---@namespace train-upgrader
+---@type Storage
+storage = storage --[[@as Storage]]
+
+local Upgrade = {}
+
+local carriage_inventories = {
   defines.inventory.fuel,
   defines.inventory.burnt_result,
   defines.inventory.cargo_wagon,
-  defines.inventory.artillery_wagon_ammo
+  defines.inventory.artillery_wagon_ammo,
 }
 
-
-function normalize_distance(distance)
+local function normalize_distance(distance)
   return (math.ceil(2 * distance))
 end
 
-function different_corner(corner1, corner2)
-  return ((normalize_distance(corner1.x) ~= normalize_distance(corner2.x)) or
-      (normalize_distance(corner1.y) ~= normalize_distance(corner2.y)))
+local function different_corner(corner1, corner2)
+  return (
+    (normalize_distance(corner1.x) ~= normalize_distance(corner2.x))
+    or (normalize_distance(corner1.y) ~= normalize_distance(corner2.y))
+  )
 end
 
-function different_box(box1, box2)
-  return (different_corner(box1.left_top, box2.left_top) or
-      different_corner(box1.right_bottom, box2.right_bottom))
+local function different_box(box1, box2)
+  return (different_corner(box1.left_top, box2.left_top) or different_corner(box1.right_bottom, box2.right_bottom))
 end
 
-function equal_mask(car1, car2)
+local function equal_mask(car1, car2)
   local mask1 = car1.collision_mask.layers
   local mask2 = car2.collision_mask.layers
   for layer, value in pairs(mask1) do
-    if (mask2[layer] ~= value) then return false end
+    if mask2[layer] ~= value then
+      return false
+    end
   end
   for layer, value in pairs(mask2) do
-    if (mask1[layer] ~= value) then return false end
+    if mask1[layer] ~= value then
+      return false
+    end
   end
   return true
 end
 
-function compatible_carriage(carriage, c2)
+local function compatible_carriage(carriage, c2)
   local c1 = carriage.prototype
-  if (c1.type ~= c2.type) then return false end
-  if (c1.name == c2.name) then return true end
-  if (different_box(c1.selection_box, c2.selection_box)) then return false end
-  if (different_box(c1.collision_box, c2.collision_box)) then return false end
-  if (not equal_mask(c1, c2)) then return false end
+  if c1.type ~= c2.type then
+    return false
+  end
+  if c1.name == c2.name then
+    return true
+  end
+  if different_box(c1.selection_box, c2.selection_box) then
+    return false
+  end
+  if different_box(c1.collision_box, c2.collision_box) then
+    return false
+  end
+  if not equal_mask(c1, c2) then
+    return false
+  end
 
   for _, inv_type in pairs(carriage_inventories) do
-    if ((inv_type ~= defines.inventory.fuel) and
-        (inv_type ~= defines.inventory.burnt_result)) then
+    if inv_type ~= defines.inventory.fuel and inv_type ~= defines.inventory.burnt_result then
       local inv = carriage.get_inventory(inv_type)
-	  if ((inv ~= nil) and (inv.valid) and (not inv.is_empty())) then
-	    local sz = c2.get_inventory_size(inv_type)
-	    if ((sz == nil) or (sz < 1)) then return false end
-	  end
-	end
+      if inv ~= nil and inv.valid and not inv.is_empty() then
+        local sz = c2.get_inventory_size(inv_type)
+        if sz == nil or sz < 1 then
+          return false
+        end
+      end
+    end
   end
 
-  if (((carriage.grid ~= nil) and (carriage.grid.count() > 0)) and
-      ((c2.grid_prototype == nil) or
-	    (c2.grid_prototype.width < carriage.grid.width) or
-		(c2.grid_prototype.height < carriage.grid.height))) then
-	return false
+  if
+    ((carriage.grid ~= nil) and (carriage.grid.count() > 0))
+    and (
+      (c2.grid_prototype == nil)
+      or (c2.grid_prototype.width < carriage.grid.width)
+      or (c2.grid_prototype.height < carriage.grid.height)
+    )
+  then
+    return false
   end
   return true
 end
 
-function upgradeable_carriage(car)
-  if (not car.can_be_destroyed()) then return false end
+local function upgradeable_carriage(car)
+  if not car.can_be_destroyed() then
+    return false
+  end
   local items = car.prototype.items_to_place_this
-  if ((items == nil) or (items[1] == nil)) then return false end
-  if ((car.type == "locomotive") or (car.type == "cargo-wagon") or
-      (car.type == "fluid-wagon") or (car.type == "artillery-wagon")) then
-	return true
+  if items == nil or items[1] == nil then
+    return false
+  end
+  if
+    car.type == "locomotive"
+    or car.type == "cargo-wagon"
+    or car.type == "fluid-wagon"
+    or car.type == "artillery-wagon"
+  then
+    return true
   end
   return false
 end
 
-
 local function car_inv(car, typ)
   local inv = car.get_inventory(typ)
-  if ((inv == nil) or (not inv.valid)) then return nil end
+  if inv == nil or not inv.valid then
+    return nil
+  end
   return inv
 end
 
-function record_inventory(car)
+local function record_inventory(car)
   local contents = nil
   for _, inv_type in pairs(carriage_inventories) do
     local inv = car_inv(car, inv_type)
-	if (inv ~= nil) then
-	  local entry = { slots = #inv }
-	  if (inv.supports_bar()) then
-	    entry.bar = inv.get_bar()
-		if (entry.bar > entry.slots) then
-		  entry.bar = nil
-		else
-		  entry.slots = entry.bar
-		end
-	  end
-	  if (inv.is_filtered()) then
-		entry.filters = { }
-		for i = 1, entry.slots do
-		  entry.filters[i] = inv.get_filter(i)
-		end
-	  end
-	  if ((not inv.is_empty()) or (entry.bar ~= nil) or
-	      (entry.filters ~= nil)) then
-		if (contents == nil) then contents = { } end
-		entry.contents = inv.get_contents()
-	    contents[inv_type] = entry
-	  end
-	end
+    if inv ~= nil then
+      local entry = { slots = #inv }
+      if inv.supports_bar() then
+        entry.bar = inv.get_bar()
+        if entry.bar > entry.slots then
+          entry.bar = nil
+        else
+          entry.slots = entry.bar
+        end
+      end
+      if inv.is_filtered() then
+        entry.filters = {}
+        for i = 1, entry.slots do
+          entry.filters[i] = inv.get_filter(i)
+        end
+      end
+      if not inv.is_empty() or entry.bar ~= nil or entry.filters ~= nil then
+        if contents == nil then
+          contents = {}
+        end
+        entry.contents = inv.get_contents()
+        contents[inv_type] = entry
+      end
+    end
   end
   return contents
 end
 
-function restore_inventory(car, contents, station)
-  if (contents == nil) then return end
+local function restore_inventory(car, contents, station)
+  if contents == nil then
+    return
+  end
   for inv_type, entry in pairs(contents) do
     local inv = car.get_inventory(inv_type)
-	if ((inv ~= nil) and inv.valid) then
-	  local slots = #inv
-	  if (inv.supports_bar() and (entry.bar ~= nil) and
-	      (entry.bar < slots)) then
-	    inv.set_bar(entry.bar)
-		slots = entry.bar
-	  end
+    if inv ~= nil and inv.valid then
+      local slots = #inv
+      if inv.supports_bar() and entry.bar ~= nil and entry.bar < slots then
+        inv.set_bar(entry.bar)
+        slots = entry.bar
+      end
 
-	  if (inv.supports_filters() and (entry.filters ~= nil)) then
-	    if (slots == entry.slots) then
-		  for i = 1, entry.slots do
-		    inv.set_filter(i, entry.filters[i])
-		  end
-		else
-		  local totals = { }
-		  local different = 0
-		  for i = 1, entry.slots do
-		    local filter = entry.filters[i]
-			if (filter == nil) then filter = " " end
-			if (totals[filter] == nil) then
-			  totals[filter] = 1
-			  different = different + 1
-			else
-			  totals[filter] = totals[filter] + 1
-			end
-		  end
-		  
-		  local oldslots = entry.slots
-		  local newslots = slots
-		  local current = 1
-		  for filter, count in pairs(totals) do
-		    local num = 1
-			if (oldslots > 0) then
-		      local fraction = (newslots * count) / oldslots
-			  num = math.max(1, math.floor(fraction + 0.5))
-			end
-			local last = current + num - 1
-			if (last > slots) then
-			  last = slots
-			end
-			if ((filter ~= " ") and (last >= current)) then
-			  for i = current, last do
-			    inv.set_filter(i, filter)
-			  end
-			end
-			current = last + 1
-			oldslots = oldslots - count
-			newslots = newslots - num
-		  end
-		end
-	  end
-
-	  for key, inv_slot in pairs(entry.contents) do
-	    itemname = inv_slot.name
-	    amount = inv_slot.count
-        quality = inv_slot.quality
-	    local inserted = inv.insert({name=itemname, count=amount, quality = quality})
-		local remaining = amount - inserted
-		if (remaining < 1) then
-            entry.contents[key] = nil
+      if inv.supports_filters() and entry.filters ~= nil then
+        if slots == entry.slots then
+          for i = 1, entry.slots do
+            inv.set_filter(i, entry.filters[i])
+          end
         else
-	      entry.contents[key].count = remaining
-        end
-	  end
-	end
+          local totals = {}
+          local different = 0
+          for i = 1, entry.slots do
+            local filter = entry.filters[i]
+            if filter == nil then
+              filter = " "
+            end
+            if totals[filter] == nil then
+              totals[filter] = 1
+              different = different + 1
+            else
+              totals[filter] = totals[filter] + 1
+            end
+          end
 
-	for _, inv_slot in pairs(entry.contents) do
-		itemname = inv_slot.name
-        amount = inv_slot.count
-		quality = inv_slot.quality
-	    for _,s in pairs(station.receivers) do
-	        local receiver = s.get_inventory(defines.inventory.chest)
-	        if ((receiver ~= nil) and receiver.can_insert({name=itemname, count=1, quality = quality})) then
-		        amount = amount - receiver.insert({name=itemname, count=amount, quality = quality})
-		        if (amount < 1) then break end
-			end
-	    end
-	end
+          local oldslots = entry.slots
+          local newslots = slots
+          local current = 1
+          for filter, count in pairs(totals) do
+            local num = 1
+            if oldslots > 0 then
+              local fraction = (newslots * count) / oldslots
+              num = math.max(1, math.floor(fraction + 0.5))
+            end
+            local last = current + num - 1
+            if last > slots then
+              last = slots
+            end
+            if filter ~= " " and last >= current then
+              for i = current, last do
+                inv.set_filter(i, filter)
+              end
+            end
+            current = last + 1
+            oldslots = oldslots - count
+            newslots = newslots - num
+          end
+        end
+      end
+
+      for key, inv_slot in pairs(entry.contents) do
+        local itemname = inv_slot.name
+        local amount = inv_slot.count
+        local quality = inv_slot.quality
+        local inserted = inv.insert({ name = itemname, count = amount, quality = quality })
+        local remaining = amount - inserted
+        if remaining < 1 then
+          entry.contents[key] = nil
+        else
+          entry.contents[key].count = remaining
+        end
+      end
+    end
+
+    for _, inv_slot in pairs(entry.contents) do
+      local itemname = inv_slot.name
+      local amount = inv_slot.count
+      local quality = inv_slot.quality
+      for _, s in pairs(station.receivers) do
+        local receiver = s.get_inventory(defines.inventory.chest)
+        if receiver ~= nil and receiver.can_insert({ name = itemname, count = 1, quality = quality }) then
+          amount = amount - receiver.insert({ name = itemname, count = amount, quality = quality })
+          if amount < 1 then
+            break
+          end
+        end
+      end
+    end
   end
 end
 
-function record_grid(grid)
-  if ((grid == nil) or (not grid.valid)) then return nil end
-  if (grid.count() < 1) then return nil end
-  local contents = { }
+local function record_grid(grid)
+  if grid == nil or not grid.valid then
+    return nil
+  end
+  if grid.count() < 1 then
+    return nil
+  end
+  local contents = {}
   local num = 0
   for _, eq in pairs(grid.equipment) do
-    if (eq.valid) then
+    if eq.valid then
       num = num + 1
-	  local entry = { name = eq.name,
-	      position = eq.position, proto = eq.prototype}
-	  if ((eq.burner ~= nil) and eq.burner.valid) then
-	    if ((eq.burner.inventory ~= nil) and eq.burner.inventory.valid) then
-	      entry.fuel = eq.burner.inventory.get_contents()
-		end
-		if ((eq.burner.burnt_result_inventory ~= nil) and
-		    eq.burner.burnt_result_inventory.valid) then
-		  entry.burnt = eq.burner.burnt_result_inventory.get_contents()
-		end
-	  end
-	  contents[num] = entry
-	end
+      local entry = { name = eq.name, position = eq.position, proto = eq.prototype }
+      if eq.burner ~= nil and eq.burner.valid then
+        if eq.burner.inventory ~= nil and eq.burner.inventory.valid then
+          entry.fuel = eq.burner.inventory.get_contents()
+        end
+        if eq.burner.burnt_result_inventory ~= nil and eq.burner.burnt_result_inventory.valid then
+          entry.burnt = eq.burner.burnt_result_inventory.get_contents()
+        end
+      end
+      contents[num] = entry
+    end
   end
   return contents
 end
 
-function restore_grid(grid, contents, station, doit)
-  if (contents == nil) then return false end
-  if ((grid == nil) or (not grid.valid)) then return false end
+local function restore_grid(grid, contents, station, doit)
+  if contents == nil then
+    return false
+  end
+  if grid == nil or not grid.valid then
+    return false
+  end
   local ret = false
   for _, eq in pairs(contents) do
     local neweq = nil
-	if (doit) then
-	  neweq = grid.put{ name = eq.name, position = eq.position }
-	end
-	if (neweq == nil) then
-	  if (eq.proto.take_result ~= nil) then
-	    local take_name = eq.proto.take_result.name
-	    for _,s in pairs(station.receivers) do
-	      local receiver = s.get_inventory(defines.inventory.chest)
-	      if ((receiver ~= nil) and receiver.can_insert(take_name) and
-		      (receiver.insert({name=take_name}) > 0)) then
-			break
-		  end
-		end
-	  end
-	else
-	  ret = true
-	  if ((neweq.burner ~= nil) and neweq.burner.valid) then
-	    local burn = neweq.burner
-	    if ((eq.fuel ~= nil) and (burn.inventory ~= nil) and
-	        burn.inventory.valid) then
-	      for _, entry in pairs(eq.fuel) do
-	        burn.inventory.insert({name=entry.name, count=entry.count,quality=entry.quality})
-			end
-	    end
-	    if ((eq.burnt ~= nil) and (burn.burnt_result_inventory ~= nil) and
-	        burn.burnt_result_inventory.valid) then
-		  for _, entry in pairs(eq.burnt) do
-	        burn.burnt_result_inventory.insert({name=entry.name, count=entry.count,quality=entry.quality})
-		  end
-	    end
-	  end
-	end
+    if doit then
+      neweq = grid.put({ name = eq.name, position = eq.position })
+    end
+    if neweq == nil then
+      if eq.proto.take_result ~= nil then
+        local take_name = eq.proto.take_result.name
+        for _, s in pairs(station.receivers) do
+          local receiver = s.get_inventory(defines.inventory.chest)
+          if receiver ~= nil and receiver.can_insert(take_name) and receiver.insert({ name = take_name }) > 0 then
+            break
+          end
+        end
+      end
+    else
+      ret = true
+      if neweq.burner ~= nil and neweq.burner.valid then
+        local burn = neweq.burner
+        if eq.fuel ~= nil and burn and burn.inventory ~= nil and burn.inventory.valid then
+          for _, entry in pairs(eq.fuel) do
+            burn.inventory.insert({ name = entry.name, count = entry.count, quality = entry.quality })
+          end
+        end
+        if eq.burnt ~= nil and burn and burn.burnt_result_inventory ~= nil and burn.burnt_result_inventory.valid then
+          for _, entry in pairs(eq.burnt) do
+            burn.burnt_result_inventory.insert({ name = entry.name, count = entry.count, quality = entry.quality })
+          end
+        end
+      end
+    end
   end
   return ret
 end
 
-
-function do_upgrade_one_carriage(train, station, car, proto, item_grid)
+local function do_upgrade_one_carriage(train, station, car, proto, item_grid)
   local front = car.get_connected_rolling_stock(defines.rail_direction.front)
   local back = car.get_connected_rolling_stock(defines.rail_direction.back)
   local pos = car.position
   local surface = car.surface
-  local frc = car.force
+  local force = car.force
   local orient = car.orientation
-  local clr = car.color
-  local sched = train.schedule
+  local color = car.color
+  local sched = train.get_schedule()
+  local records = sched.get_records()
+  local interrupts = sched.get_interrupts()
+  local old_current = sched.current
   local oldid = train.id
   local manual = train.manual_mode
 
   local burner_current = nil
   local burner_remaining = nil
-  if ((car.burner ~= nil) and car.burner.valid) then
+  if car.burner ~= nil and car.burner.valid then
     burner_current = car.burner.currently_burning
     burner_remaining = car.burner.remaining_burning_fuel
   end
@@ -284,252 +331,323 @@ function do_upgrade_one_carriage(train, station, car, proto, item_grid)
   local contents = record_inventory(car)
   local grid = record_grid(car.grid)
   local fluid_content = nil
-  if (car.type == "fluid-wagon") then
+  if car.type == "fluid-wagon" then
     fluid_content = car.get_fluid_contents()
   end
 
-  if (not car.destroy{raise_destroy=true}) then return end
-  local newcar = surface.create_entity{name=proto.name, position=pos,
-      force=frc, raise_built=true, orientation=orient, color=clr}
+  if not car.destroy({ raise_destroy = true }) then
+    return
+  end
+  local newcar = surface.create_entity({
+    name = proto.name,
+    position = pos,
+    force = force,
+    raise_built = true,
+    orientation = orient,
+  })
 
-  if (front ~= nil) then
+  --copy color from old entity, if wanted
+  if settings.startup["tu-copy-color"].value then
+    newcar.color = color
+  end
+
+  if front ~= nil then
     newcar.connect_rolling_stock(defines.rail_direction.front)
   end
-  if (back ~= nil) then
+  if back ~= nil then
     newcar.connect_rolling_stock(defines.rail_direction.back)
   end
 
-  if (fluid_content ~= nil) then
+  if fluid_content ~= nil then
     for fluidname, fluidcount in pairs(fluid_content) do
-	  newcar.insert_fluid({name=fluidname, amount=fluidcount})
-	end
+      newcar.insert_fluid({ name = fluidname, amount = fluidcount })
+    end
   end
 
   restore_inventory(newcar, contents, station)
   local transfer_grid = true
-  if ((item_grid ~= nil) and
-      restore_grid(newcar.grid, item_grid, station, true)) then
-	transfer_grid = false
+  if item_grid ~= nil and restore_grid(newcar.grid, item_grid, station, true) then
+    transfer_grid = false
   end
   restore_grid(newcar.grid, grid, station, transfer_grid)
 
-  if ((newcar.burner ~= nil) and newcar.burner.valid and
-      (burner_current ~= nil) and (burner_current.fuel_category ~= nil) and
-	  (newcar.burner.fuel_categories[burner_current.fuel_category] == true)) then
-	newcar.burner.currently_burning = burner_current
-	if (burner_remaining ~= nil) then
-	  newcar.burner.remaining_burning_fuel = burner_remaining
-	end
+  if
+    newcar.burner ~= nil
+    and newcar.burner.valid
+    and burner_current ~= nil
+    and burner_current.name.fuel_category ~= nil
+    and newcar.burner.fuel_categories[burner_current.name.fuel_category] == true
+  then
+    newcar.burner.currently_burning = burner_current
+    if burner_remaining ~= nil then
+      newcar.burner.remaining_burning_fuel = burner_remaining
+    end
   end
 
   local pending = station.pending[oldid]
-  if (pending ~= nil) then
-	station.pending[oldid] = nil
+  if pending ~= nil then
+    station.pending[oldid] = nil
   end
-  
+
   local newtrain = newcar.train
-  if (newtrain ~= nil) then
-    newtrain.schedule = sched
-	newtrain.manual_mode = manual
-	if (pending ~= nil) then
-	  pending.train = newtrain
+  if newtrain ~= nil then
+    local new_sched = newtrain.get_schedule()
+    if records ~= nil then
+      new_sched.set_records(records)
+    end
+    new_sched.set_interrupts(interrupts)
+    -- next line is essential or the mod doesn't put fuel in the new loco - if fuel <>
+    new_sched.go_to_station(old_current) -- sets train to automatic
+    if pending ~= nil then
+      pending.train = newtrain
       station.pending[newtrain.id] = pending
-	end
+    end
   end
 end
 
-
-function replace_fuel(carriage, fuel_supply, station, doit)
+local function replace_fuel(carriage, fuel_supply, station, doit)
   local skip = true
   for new_fuel, new_num in pairs(fuel_supply) do
-    local threshold = math.max(1, math.min(20,
-	    (prototypes.item[new_fuel].stack_size * 0.5)))
-	if (new_num < threshold) then
-	  fuel_supply[new_fuel] = nil
-	else
-	  skip = false
-	end
+    ---@type number
+    local threshold = math.max(1, math.min(20, (prototypes.item[new_fuel].stack_size * 0.5)))
+    if new_num < threshold then
+      fuel_supply[new_fuel] = nil
+    else
+      skip = false
+    end
   end
-  if (skip) then return false end
+  if skip then
+    return false
+  end
 
   local burner = carriage.burner
   local burn_inv = burner.inventory
   local result_inv = burner.burnt_result_inventory
-  if (burn_inv.is_empty() and result_inv.is_empty()) then
-	local best_fuel = nil
-	local best_value = 0
-	local best_amount = 0
-	for new_fuel, new_num in pairs(fuel_supply) do
-	  local insertable = burn_inv.get_insertable_count(new_fuel)
-	  local amount = math.min(insertable, new_num)
-	  local new_proto = prototypes.item[new_fuel]
-	  local value = (amount * new_proto.fuel_value *
-		  new_proto.fuel_acceleration_multiplier *
-		  new_proto.fuel_top_speed_multiplier)
-	  if (value > best_value) then
-		best_fuel = new_fuel
-		best_value = value
-		best_amount = amount
-	  end
-	end
+  if burn_inv.is_empty() and result_inv.is_empty() then
+    local best_fuel = nil
+    local best_value = 0.0
+    local best_amount = 0.0
+    for new_fuel, new_num in pairs(fuel_supply) do
+      local insertable = burn_inv.get_insertable_count(new_fuel)
+      local amount = math.min(insertable, new_num)
+      local new_proto = prototypes.item[new_fuel]
+      local value = (
+        amount
+        * new_proto.fuel_value
+        * new_proto.fuel_acceleration_multiplier
+        * new_proto.fuel_top_speed_multiplier
+      )
+      if value > best_value then
+        best_fuel = new_fuel
+        best_value = value
+        best_amount = amount
+      end
+    end
 
-	if (best_fuel == nil) then return false end
-    if (doit) then
-	  local fuel_stack = { name = best_fuel, count = best_amount }
-	  fuel_stack.count = burn_inv.insert(fuel_stack)
-	  for _,s in pairs(station.suppliers) do
-		local sinv = s.get_inventory(defines.inventory.chest)
-		if ((sinv ~= nil) and (fuel_stack.count >= 1)) then
-		  local removed = sinv.remove(fuel_stack)
-		  fuel_stack.count = fuel_stack.count - removed
-		end
-	  end
-	end
-	return true
+    if best_fuel == nil then
+      return false
+    end
+    if doit then
+      local fuel_stack = { name = best_fuel, count = best_amount }
+      fuel_stack.count = burn_inv.insert(fuel_stack)
+      for _, s in pairs(station.suppliers) do
+        local sinv = s.get_inventory(defines.inventory.chest)
+        if sinv ~= nil and fuel_stack.count >= 1 then
+          local removed = sinv.remove(fuel_stack)
+          fuel_stack.count = fuel_stack.count - removed
+        end
+      end
+    end
+    return true
   end
 
   local fuel_contents = burn_inv.get_contents()
   for old_fuel, old_num in pairs(fuel_contents) do
-  	local old_proto = prototypes.item[old_fuel]
-    if ((fuel_supply[old_fuel] == nil) and (old_proto ~= nil)) then
-	  local stack = { name = old_fuel, count = old_num }
-	  local burnt_stack = nil
-	  local burnt_receiver = nil
-	  if (old_proto.burnt_result ~= nil) then
-	    local burnt_name = old_proto.burnt_result.name
-	    local burnt_count = result_inv.get_item_count(burnt_name)
-		if (burner.currently_burning == old_proto) then
-		  burnt_count = burnt_count + 1
-		end
-		if (burnt_count >= 1) then
-	      burnt_stack = { name = burnt_name, count = burnt_count }
-		  for _, r in pairs(station.receivers) do
-	        local rinv = r.get_inventory(defines.inventory.chest)
-	        if ((rinv ~= nil) and rinv.can_insert(burnt_stack)) then
-			  burnt_receiver = r
-			end
-		  end
-		end
-	  end
+    local old_proto = prototypes.item[old_fuel]
+    if fuel_supply[old_fuel] == nil and old_proto ~= nil then
+      local stack = { name = old_fuel, count = old_num }
+      local burnt_stack = nil
+      local burnt_receiver = nil --[[@as table]]
+      if old_proto.burnt_result ~= nil then
+        local burnt_name = old_proto.burnt_result.name
+        local burnt_count = result_inv.get_item_count(burnt_name)
+        if burner.currently_burning == old_proto then
+          burnt_count = burnt_count + 1
+        end
+        if burnt_count >= 1 then
+          burnt_stack = { name = burnt_name, count = burnt_count }
+          for _, receiver in pairs(station.receivers) do
+            local rinv = receiver.get_inventory(defines.inventory.chest)
+            if rinv ~= nil and rinv.can_insert(burnt_stack) then
+              burnt_receiver = receiver
+            end
+          end
+        end
+      end
 
-	  if ((burnt_stack == nil) or (burnt_receiver ~= nil)) then
+      if burnt_stack == nil or burnt_receiver ~= nil then
         for _, r in pairs(station.receivers) do
-	      local rinv = r.get_inventory(defines.inventory.chest)
-	      if ((rinv ~= nil) and rinv.can_insert(stack)) then
-		    if (doit) then
-		      stack.count = burn_inv.remove(stack)
-			  rinv.insert(stack)
-			  if (burnt_stack ~= nil) then
-			    burnt_stack.count = result_inv.remove(burnt_stack)
-				burnt_receiver.insert(burnt_stack)
-				if (burner.currently_burning == old_proto) then
-				  burner.remaining_burning_fuel = 0
-				  burner.currently_burning = nil
-				end
-			  end
-		    end
-		    return true
-		  end
-		end
-	  end
-	end
+          local rinv = r.get_inventory(defines.inventory.chest)
+          if rinv ~= nil and rinv.can_insert(stack) then
+            if doit then
+              stack.count = burn_inv.remove(stack)
+              rinv.insert(stack)
+              if burnt_stack ~= nil then
+                burnt_stack.count = result_inv.remove(burnt_stack)
+                assert(burnt_receiver ~= nil)
+                burnt_receiver.insert(burnt_stack)
+                if burner.currently_burning == old_proto then
+                  burner.remaining_burning_fuel = 0
+                  burner.currently_burning = nil
+                end
+              end
+            end
+            return true
+          end
+        end
+      end
+    end
   end
   return false
 end
 
-
-function try_upgrade_one_carriage(carriage, train, station, doit)
+local function try_upgrade_one_carriage(carriage, train, station, doit)
   local upgradeable = upgradeable_carriage(carriage)
   local burner = carriage.burner
-  if ((burner ~= nil) and (not burner.valid)) then burner = nil end
-  if (not (upgradeable or (burner ~= nil))) then return false end
+  if burner ~= nil and not burner.valid then
+    burner = nil
+  end
+  if not (upgradeable or burner ~= nil) then
+    return false
+  end
 
   local same = false
   local new_entity = nil
-  local new_item = nil
-  local new_inv = nil
+  ---@type ItemWithQualityID
+  local new_item
+  ---@type LuaInventory
+  local new_inv
   local fuel_supply = nil
 
-  for _,s in pairs(station.suppliers) do
-	local supply_inv = s.get_inventory(defines.inventory.chest)
-	if (supply_inv ~= nil) then
-	  local supply_contents = supply_inv.get_contents()
-	  for _,inv_slot in pairs(supply_contents) do
-	    supply_name = inv_slot.name
-	    supply_count = inv_slot.count
-	    -- TODO: manage quality too 
-		local item_proto = prototypes.item[supply_name]
-		if (item_proto ~= nil) then
-		  if (upgradeable and (item_proto.place_result ~= nil) and
-			  compatible_carriage(carriage, item_proto.place_result)) then
-		    local matches = false
-		    for _,item in pairs(carriage.prototype.items_to_place_this) do
-			  if (item.name == supply_name) then
-			    matches = true
-			  end
-		    end
-		    if (matches) then
-			  same = true
-		    else
-			  new_entity = item_proto.place_result
-			  new_item = supply_name
-			  new_inv = supply_inv
-			end
-	      end
+  for _, s in pairs(station.suppliers) do
+    local supply_inv = s.get_inventory(defines.inventory.chest)
+    if supply_inv ~= nil then
+      local supply_contents = supply_inv.get_contents()
+      for _, inv_slot in pairs(supply_contents) do
+        local supply_name = inv_slot.name
+        local supply_count = inv_slot.count
+        -- TODO: manage quality too
+        local item_proto = prototypes.item[supply_name]
+        if item_proto ~= nil then
+          if
+            upgradeable
+            and (item_proto.place_result ~= nil)
+            and compatible_carriage(carriage, item_proto.place_result)
+          then
+            local matches = false
+            for _, item in pairs(carriage.prototype.items_to_place_this) do
+              if item.name == supply_name then
+                matches = true
+              end
+            end
+            if matches then
+              same = true
+            else
+              new_entity = item_proto.place_result
+              new_item = supply_name
+              new_inv = supply_inv
+            end
+          end
 
-		  if ((burner ~= nil) and (item_proto.fuel_category ~= nil) and
-			  (item_proto.fuel_value > 0) and
-			  (burner.fuel_categories[item_proto.fuel_category] == true)) then
-			if (fuel_supply == nil) then fuel_supply = { } end
-			local old_count = fuel_supply[supply_name]
-			if (old_count ~= nil) then
-			  supply_count = supply_count + old_count
-			end
-			fuel_supply[supply_name] = supply_count
-		  end
-		end
+          if
+            (burner ~= nil)
+            and (item_proto.fuel_category ~= nil)
+            and (item_proto.fuel_value > 0)
+            and (burner.fuel_categories[item_proto.fuel_category] == true)
+          then
+            if fuel_supply == nil then
+              fuel_supply = {}
+            end
+            local old_count = fuel_supply[supply_name]
+            if old_count ~= nil then
+              supply_count = supply_count + old_count
+            end
+            fuel_supply[supply_name] = supply_count
+          end
+        end
       end
-	end
+    end
   end
 
-  if ((new_entity ~= nil) and (not same)) then
+  if new_entity ~= nil and not same then
     local item_grid = nil
-	if (doit) then
-	  local new_stack = new_inv.find_item_stack(new_item)
-	  if ((new_stack ~= nil) and (new_stack.grid ~= nil)) then
-	    item_grid = record_grid(new_stack.grid)
-	  end
-	end
+    if doit then
+      local new_stack = new_inv.find_item_stack(new_item)
+      if new_stack ~= nil and new_stack.grid ~= nil then
+        item_grid = record_grid(new_stack.grid)
+      end
+    end
 
-    for _,s in pairs(station.receivers) do
-	  local receive_inv = s.get_inventory(defines.inventory.chest)
-	  if (receive_inv ~= nil) then
-		for _,item in pairs(carriage.prototype.items_to_place_this) do
-		  if (receive_inv.can_insert(item)) then
-			if (doit and (new_inv.remove({name=new_item}) > 0)) then
-			  receive_inv.insert(item)
-			  do_upgrade_one_carriage(train, station,
-				  carriage, new_entity, item_grid)
-			end
-			return true
-		  end
-		end
-	  end
-	end
+    for _, s in pairs(station.receivers) do
+      local receive_inv = s.get_inventory(defines.inventory.chest)
+      if receive_inv ~= nil then
+        for _, item in pairs(carriage.prototype.items_to_place_this) do
+          if receive_inv.can_insert(item) then
+            if
+              doit and (
+                new_inv.remove({ name = new_item }--[[@as ItemStackIdentification]]) > 0
+              )
+            then
+              receive_inv.insert(item)
+              do_upgrade_one_carriage(train, station, carriage, new_entity, item_grid)
+            end
+            return true
+          end
+        end
+      end
+    end
   end
 
-  if ((fuel_supply ~= nil) and
-      replace_fuel(carriage, fuel_supply, station, doit)) then
+  if fuel_supply ~= nil and replace_fuel(carriage, fuel_supply, station, doit) then
     return true
   end
   return false
 end
 
-function upgrade_any_carriage(train, station, doit)
+function Upgrade.upgrade_any_carriage(train, station, doit)
   for _, carriage in pairs(train.carriages) do
-    if (try_upgrade_one_carriage(carriage, train, station, doit)) then
-	  return true
-	end
+    if try_upgrade_one_carriage(carriage, train, station, doit) then
+      return true
+    end
   end
   return false
 end
+
+local function on_train_schedule_changed(event)
+  ---@type LuaTrain
+  local train = event.train
+  if event.player_index or storage.station_head == nil then
+    return
+  end
+
+  local schedule = train.get_schedule()
+  local count = schedule.get_record_count()
+  if count == nil or count < 3 then
+    return
+  end
+  local current = schedule.get_record({ schedule_index = schedule.current })
+  local last = schedule.get_record({ schedule_index = count })
+  ---@cast last -?
+  if current and current.created_by_interrupt == true then
+    if Station.special_stop(last) then
+      -- An interrupt actived and disturbed the ATU upgrade
+      schedule.remove_record({ schedule_index = schedule.current })
+      -- The train is still in automode and should still be at the TU station
+      -- schedule.go_to_station(count)
+    end
+  end
+end
+
+script.on_event(defines.events.on_train_schedule_changed, on_train_schedule_changed)
+
+return Upgrade

--- a/train-upgrader/settings.lua
+++ b/train-upgrader/settings.lua
@@ -1,0 +1,9 @@
+data:extend({
+  {
+    type = "bool-setting",
+    name = "tu-copy-color",
+    setting_type = "startup",
+    default_value = false,
+    order = "a",
+  },
+})


### PR DESCRIPTION
- Fixed group and interrupt deletion
- Added Cybersyn 2 support (may not be perfect)
- Added interrupt handling, when an interrupt activates while upgrading the train, eg. Refuel
- Added radius visualization to both chests, so you can see how far they can be from the Station (beacon like)
- Added a setting to make color copy optional(default off)
- converted all global function to a proper context
- Added annotations and comments, to help understand the mod better

All development was done in Factorio 2.1 and made compatible for Factorio 2.0 as nullius is still on 2.0, so there was limited testing on 2.0